### PR TITLE
Fix flawed sql query on empty list

### DIFF
--- a/framework/src/main/groovy/org/moqui/impl/entity/condition/FieldValueCondition.groovy
+++ b/framework/src/main/groovy/org/moqui/impl/entity/condition/FieldValueCondition.groovy
@@ -54,32 +54,35 @@ class FieldValueCondition extends EntityConditionImplBase {
     @Override
     void makeSqlWhere(EntityQueryBuilder eqb) {
         StringBuilder sql = eqb.getSqlTopLevel()
-        int typeValue = -1
-        if (ignoreCase) {
-            typeValue = field.getFieldInfo(eqb.getMainEd())?.typeValue ?: 1
-            if (typeValue == 1) sql.append("UPPER(")
-        }
-
-        sql.append(field.getColumnName(eqb.getMainEd()))
-        if (ignoreCase && typeValue == 1) sql.append(')')
-        sql.append(' ')
-
         boolean valueDone = false
-        if (value == null) {
-            if (operator == EQUALS || operator == LIKE || operator == IN || operator == BETWEEN) {
-                sql.append(" IS NULL")
-                valueDone = true
-            } else if (operator == NOT_EQUAL || operator == NOT_LIKE || operator == NOT_IN || operator == NOT_BETWEEN) {
-                sql.append(" IS NOT NULL")
-                valueDone = true
-            }
-        } else if (value instanceof Collection && ((Collection) value).isEmpty()) {
+
+        if (value instanceof Collection && ((Collection) value).isEmpty()) {
             if (operator == IN) {
                 sql.append(" 1 = 2 ")
                 valueDone = true
             } else if (operator == NOT_IN) {
                 sql.append(" 1 = 1 ")
                 valueDone = true
+            }
+        } else {
+            int typeValue = -1
+            if (ignoreCase) {
+                typeValue = field.getFieldInfo(eqb.getMainEd())?.typeValue ?: 1
+                if (typeValue == 1) sql.append("UPPER(")
+            }
+
+            sql.append(field.getColumnName(eqb.getMainEd()))
+            if (ignoreCase && typeValue == 1) sql.append(')')
+            sql.append(' ')
+
+            if (value == null) {
+                if (operator == EQUALS || operator == LIKE || operator == IN || operator == BETWEEN) {
+                    sql.append(" IS NULL")
+                    valueDone = true
+                } else if (operator == NOT_EQUAL || operator == NOT_LIKE || operator == NOT_IN || operator == NOT_BETWEEN) {
+                    sql.append(" IS NOT NULL")
+                    valueDone = true
+                }
             }
         }
         if (operator == IS_NULL || operator == IS_NOT_NULL) {

--- a/framework/src/main/groovy/org/moqui/impl/screen/ScreenRenderImpl.groovy
+++ b/framework/src/main/groovy/org/moqui/impl/screen/ScreenRenderImpl.groovy
@@ -367,7 +367,8 @@ class ScreenRenderImpl implements ScreenRender {
                         wfi.removeScreenLastParameters(ri.type == "screen-last")
                     } else {
                         // try screen history when no last was saved
-                        Map historyMap = wfi.getScreenHistory()?.get(0)
+                        List historyList = wfi.getScreenHistory()
+                        Map historyMap = historyList ? historyList.first() : null
                         if (historyMap) {
                             url = ri.type == "screen-last" ? historyMap.url : historyMap.urlNoParams
                             urlType = "plain"


### PR DESCRIPTION
This call:
```
<entity-find entity-name="moqui.example.Example" list="list">
    <econdition field-name="exampleId" operator="in" from="[]"/>
</entity-find>
```
Creates flawed SQL query:
```
org.moqui.entity.EntityException: Error in query for:SELECT EXAMPLE_ID, EXAMPLE_TYPE_ENUM_ID, STATUS_ID, EXAMPLE_NAME, DESCRIPTION, LONG_DESCRIPTION, COMMENTS, EXAMPLE_SIZE, EXAMPLE_DATE, TEST_DATE, TEST_TIME, AUDITED_FIELD, ENCRYPTED_FIELD, EXAMPLE_EMAIL, EXAMPLE_URL, LAST_UPDATED_STAMP FROM public.EXAMPLE WHERE EXAMPLE_ID  1 = 2 
	at org.moqui.impl.entity.EntityQueryBuilder.executeQuery(EntityQueryBuilder.groovy:109) ~[moqui-framework-1.6.1.jar:1.6.1]
	at org.moqui.impl.entity.EntityFindImpl.iteratorExtended(EntityFindImpl.groovy:155) ~[moqui-framework-1.6.1.jar:1.6.1]
	at org.moqui.impl.entity.EntityFindBase.listInternal(EntityFindBase.groovy:827) ~[moqui-framework-1.6.1.jar:1.6.1]
	at org.moqui.impl.entity.EntityFindBase.list(EntityFindBase.groovy:751) ~[moqui-framework-1.6.1.jar:1.6.1]
	at avance_asset_AssetServices_find_Example.run(avance_asset_AssetServices_find_Example:5) ~[?:?]
	at org.moqui.impl.actions.XmlAction.run(XmlAction.groovy:100) ~[moqui-framework-1.6.1.jar:1.6.1]
	at org.moqui.impl.service.runner.InlineServiceRunner.runService(InlineServiceRunner.groovy:54) ~[moqui-framework-1.6.1.jar:1.6.1]
	at org.moqui.impl.service.ServiceCallSyncImpl.callSingle(ServiceCallSyncImpl.groovy:288) ~[moqui-framework-1.6.1.jar:1.6.1]
	at org.moqui.impl.service.ServiceCallSyncImpl.call(ServiceCallSyncImpl.groovy:144) ~[moqui-framework-1.6.1.jar:1.6.1]
	at ServiceRun_xml_transition_run_actions.run(ServiceRun_xml_transition_run_actions:10) [script:?]
	at org.moqui.impl.actions.XmlAction.run(XmlAction.groovy:100) [moqui-framework-1.6.1.jar:1.6.1]
	at org.moqui.impl.screen.ScreenDefinition$TransitionItem.run(ScreenDefinition.groovy:686) [moqui-framework-1.6.1.jar:1.6.1]
	at org.moqui.impl.screen.ScreenRenderImpl.recursiveRunTransition(ScreenRenderImpl.groovy:225) [moqui-framework-1.6.1.jar:1.6.1]
	at org.moqui.impl.screen.ScreenRenderImpl.recursiveRunTransition(ScreenRenderImpl.groovy:219) [moqui-framework-1.6.1.jar:1.6.1]
	at org.moqui.impl.screen.ScreenRenderImpl.recursiveRunTransition(ScreenRenderImpl.groovy:219) [moqui-framework-1.6.1.jar:1.6.1]
	at org.moqui.impl.screen.ScreenRenderImpl.recursiveRunTransition(ScreenRenderImpl.groovy:219) [moqui-framework-1.6.1.jar:1.6.1]
	at org.moqui.impl.screen.ScreenRenderImpl.recursiveRunTransition(ScreenRenderImpl.groovy:219) [moqui-framework-1.6.1.jar:1.6.1]
	at org.moqui.impl.screen.ScreenRenderImpl.internalRender(ScreenRenderImpl.groovy:320) [moqui-framework-1.6.1.jar:1.6.1]
	at org.moqui.impl.screen.ScreenRenderImpl.render(ScreenRenderImpl.groovy:166) [moqui-framework-1.6.1.jar:1.6.1]
	at org.moqui.impl.webapp.MoquiServlet.doScreenRequest(MoquiServlet.groovy:73) [moqui-framework-1.6.1.jar:1.6.1]
	at org.moqui.impl.webapp.MoquiServlet.doPost(MoquiServlet.groovy:39) [moqui-framework-1.6.1.jar:1.6.1]
	at javax.servlet.http.HttpServlet.service(HttpServlet.java:713) [moqui-1.6.1.war:1.2]
	at javax.servlet.http.HttpServlet.service(HttpServlet.java:806) [moqui-1.6.1.war:1.2]
	at net.winstone.core.ServletConfiguration.execute(ServletConfiguration.java:270) [moqui-1.6.1.war:1.7.0]
	at net.winstone.core.SimpleRequestDispatcher.forward(SimpleRequestDispatcher.java:290) [moqui-1.6.1.war:1.7.0]
	at net.winstone.core.listener.RequestHandlerThread.processRequest(RequestHandlerThread.java:212) [moqui-1.6.1.war:1.7.0]
	at net.winstone.core.listener.RequestHandlerThread.run(RequestHandlerThread.java:143) [moqui-1.6.1.war:1.7.0]
	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511) [?:1.8.0_71]
	at java.util.concurrent.FutureTask.run(FutureTask.java:266) [?:1.8.0_71]
	at net.winstone.util.BoundedExecutorService$1.run(BoundedExecutorService.java:81) [moqui-1.6.1.war:1.7.0]
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142) [?:1.8.0_71]
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617) [?:1.8.0_71]
	at java.lang.Thread.run(Thread.java:745) [?:1.8.0_71]
Caused by: org.postgresql.util.PSQLException: ERROR: syntax error at or near "1"
  Position: 275
	at org.postgresql.core.v3.QueryExecutorImpl.receiveErrorResponse(QueryExecutorImpl.java:2182) ~[postgresql-9.4.1207.jar:9.4.1207]
	at org.postgresql.core.v3.QueryExecutorImpl.processResults(QueryExecutorImpl.java:1911) ~[postgresql-9.4.1207.jar:9.4.1207]
	at org.postgresql.core.v3.QueryExecutorImpl.execute(QueryExecutorImpl.java:173) ~[postgresql-9.4.1207.jar:9.4.1207]
	at org.postgresql.jdbc.PgStatement.execute(PgStatement.java:622) ~[postgresql-9.4.1207.jar:9.4.1207]
	at org.postgresql.jdbc.PgStatement.executeWithFlags(PgStatement.java:472) ~[postgresql-9.4.1207.jar:9.4.1207]
	at org.postgresql.jdbc.PgStatement.executeQuery(PgStatement.java:386) ~[postgresql-9.4.1207.jar:9.4.1207]
	at org.postgresql.ds.PGPooledConnection$StatementHandler.invoke(PGPooledConnection.java:466) ~[postgresql-9.4.1207.jar:9.4.1207]
	at com.sun.proxy.$Proxy36.executeQuery(Unknown Source) ~[?:?]
	at bitronix.tm.resource.jdbc.proxy.PreparedStatementJavaProxy.executeQuery(PreparedStatementJavaProxy.java:102) ~[btm-3.0.0-SNAPSHOT.jar:3.0.0-SNAPSHOT]
```
Plus additional minor fix for exception thrown if screen history is empty:
```
java.lang.IndexOutOfBoundsException: Index: 0, Size: 0
	at java.util.LinkedList.checkElementIndex(LinkedList.java:555) ~[?:1.8.0_71]
	at java.util.LinkedList.get(LinkedList.java:476) ~[?:1.8.0_71]
	at org.moqui.impl.screen.ScreenRenderImpl.internalRender(ScreenRenderImpl.groovy:370) ~[?:?]
	at org.moqui.impl.screen.ScreenRenderImpl.render(ScreenRenderImpl.groovy:166) ~[?:?]
	at org.moqui.impl.webapp.MoquiServlet.doScreenRequest(MoquiServlet.groovy:73) ~[?:?]
	at org.moqui.impl.webapp.MoquiServlet.doPost(MoquiServlet.groovy:39) ~[?:?]
	at javax.servlet.http.HttpServlet.service(HttpServlet.java:713) ~[moqui-1.6.2.war:1.2]
	at javax.servlet.http.HttpServlet.service(HttpServlet.java:806) ~[moqui-1.6.2.war:1.2]
```