### PR TITLE
When using dependencyUpdates don't show pre-releases

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -75,7 +75,7 @@ Written in 2014-2015 by Yao Chunlin - chunlinyao
 Written in 2015 by Dony Zulkarnaen - donniexyz
 Written in 2015 by Swapnil M Mane - swapnilmmane
 Written in 2015 by Jimmy Shen - shendepu
-Written in 2015 by Sam Hamilton - samhamilton
+Written in 2015-2016 by Sam Hamilton - samhamilton
 Written in 2015 by Leonardo Carvalho - CarvalhoLeonardo
 Written in 2015 by Anton Akhiar - akhiar
 Writter in 2015-2015 by Jens Hardings - jenshp

--- a/framework/build.gradle
+++ b/framework/build.gradle
@@ -29,6 +29,19 @@ buildscript {
   dependencies { classpath 'com.github.ben-manes:gradle-versions-plugin:0.12.0' }
 }
 
+dependencyUpdates.resolutionStrategy = {
+  componentSelection { rules ->
+    rules.all { ComponentSelection selection ->
+      boolean rejected = ['alpha', 'beta', 'rc', 'cr', 'm'].any { qualifier ->
+        selection.candidate.version ==~ /(?i).*[.-]${qualifier}[.\d-]*/
+      }
+      if (rejected) {
+        selection.reject('Release candidate')
+      }
+    }
+  }
+}
+
 sourceCompatibility = '1.7'
 archivesBaseName = 'moqui'
 


### PR DESCRIPTION
A quick change to help the report for dependencyUpdates be more useful by not showing pre-release software. 