### PR TITLE
Improve setSequencedIdSecondary performance

### DIFF
--- a/framework/src/main/groovy/org/moqui/impl/entity/EntityValueBase.groovy
+++ b/framework/src/main/groovy/org/moqui/impl/entity/EntityValueBase.groovy
@@ -416,7 +416,7 @@ abstract class EntityValueBase implements EntityValue {
             //     after the line that calls put() in the EntityDefinition.setString() method; theory is that groovy
             //     is doing something that results in fields getting set to null, probably a call to a method on
             //     EntityValueBase or EntityValueImpl that is not expected to be called
-            EntityFind ef = getEntityFacadeImpl().find(getEntityName()).condition(otherPkMap)
+            EntityFind ef = getEntityFacadeImpl().find(getEntityName()).selectField(seqFieldName).condition(otherPkMap)
             // logger.warn("TOREMOVE in setSequencedIdSecondary ef WHERE=${ef.getWhereEntityCondition()}")
             allValues = ef.list()
         } finally {


### PR DESCRIPTION
I have a slow service when create 5000 records. logProfilingDetail() shown many time is used by setSequencedIdSecondary. Though use secondary sequence id for large data set is a design mistake. This change make create 5000 records five times fast.

I have another version use plain SQL  and is more faster. Fetch one line `order by char_length(seqId) desc, seqId desc`, But It seems plain SQL method is over optimized.
