### PR TITLE
Use minimal / original URL when redirecting or saving screen

### DIFF
--- a/framework/src/main/groovy/org/moqui/impl/screen/ScreenRenderImpl.groovy
+++ b/framework/src/main/groovy/org/moqui/impl/screen/ScreenRenderImpl.groovy
@@ -479,7 +479,7 @@ class ScreenRenderImpl implements ScreenRender {
 
                         web.sendJsonResponse(responseMap)
                     } else {
-                        String fullUrlString = fullUrl.getUrlWithParams()
+                        String fullUrlString = fullUrl.getMinimalPathUrlWithParams()
                         logger.info("Finished transition ${getScreenUrlInfo().getFullPathNameList()} in ${(System.currentTimeMillis() - transitionStartTime)/1000} seconds, redirecting to screen path URL: ${fullUrlString}")
                         response.sendRedirect(fullUrlString)
                     }
@@ -766,7 +766,7 @@ class ScreenRenderImpl implements ScreenRender {
             // save the request as a save-last to use after login
             if (wfi != null && screenUrlInfo.fileResourceRef == null) {
                 StringBuilder screenPath = new StringBuilder()
-                for (String pn in screenUrlInfo.fullPathNameList) screenPath.append("/").append(pn)
+                for (String pn in originalScreenPathNameList) screenPath.append("/").append(pn)
                 wfi.saveScreenLastInfo(screenPath.toString(), null)
                 // save messages in session before redirecting so they can be displayed on the next screen
                 wfi.saveMessagesToSession()


### PR DESCRIPTION
This pull request addresses the same problem that motivated https://github.com/moqui/moqui-runtime/pull/21

When using subscreens.conditional-default it does not work as expected when using redirections.

As an example, I added two conditions to the webroot/apps.xml screens in the moqui-runtime repository (see https://github.com/jenshp/moqui-runtime/commit/b1be88f99dd880cc974c43b37456321734802efc#diff-995eb65909b710c0617cef8bb439e5d1) so that a user with permissions to view the System application would go directly there, a user with permission to view the Tools application but not to view the System application would go directly to Tools, and a user with neither of these permissions would see the default AppList.

The problem is that, before logging in, a redirection is made to the login page with previously saving the last page, because the apps.xml screen requires a logged in user (the URL is defined at line 769 of ScreenRenderImpl.groovy). As the URL used to save the last screen is the expanded one in which the subscreens.conditional-defaults have been evaluated using the context before logging in, the redirection after the login gets the user to the AppList subscreen in the above example, regardless if he has the view permission on the System or Tools applications, because the subscreens.conditional-default tags are not considered at this time (the redirection specifies a specific subscreen, so no default is applied).

A similar thing happens when logging out of moqui. The user gets redirected to the most specific subscreen calculated upon the root, using the context of no logged in user. Again, in this case it should redirect to the root, so that the specific subscreens to be rendered are calculated in the appropriate context.

The changes in this pull request use the minimal or original URL for these redirections or saved screens, so the evaluation occurs at the moment of rendering instead of in a previous HTTP request.