### PR TITLE
Dialog icons

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -48,6 +48,7 @@ Written in 2015 by Anton Akhiar - akhiar
 Writter in 2015-2015 by Jens Hardings - jenshp
 Writter in 2016 by Shifeng Zhang - zhangshifeng
 Written in 2016 by Scott Gray - lektran
+Written in 2016 by Jens Hardings - jenshp
 
 ===========================================================================
 
@@ -82,3 +83,4 @@ Written in 2015 by Anton Akhiar - akhiar
 Writter in 2015-2015 by Jens Hardings - jenshp
 Writter in 2016 by Shifeng Zhang - zhangshifeng
 Wrttien in 2016 by Scott Gray - lektran
+Written in 2016 by Jens Hardings - jenshp

--- a/framework/xsd/xml-screen-1.6.xsd
+++ b/framework/xsd/xml-screen-1.6.xsd
@@ -780,6 +780,7 @@ along with this software (see the LICENSE.md file). If not, see
             <xs:group ref="widget-elements" minOccurs="0" maxOccurs="unbounded"/>
             <xs:attribute name="id" type="xs:string" use="required"/>
             <xs:attribute name="button-text" type="xs:string" use="required"/>
+            <xs:attribute name="button-icon" type="xs:string" use="optional"/>
             <xs:attribute name="width" type="xs:string" default="600"/>
             <xs:attribute name="height" type="xs:string" default="600"/>
         </xs:complexType>
@@ -791,6 +792,7 @@ along with this software (see the LICENSE.md file). If not, see
             <xs:sequence><xs:element minOccurs="0" maxOccurs="unbounded" ref="parameter"/></xs:sequence>
             <xs:attribute name="id" type="xs:string" use="required"/>
             <xs:attribute name="button-text" type="xs:string" use="required"/>
+            <xs:attribute name="button-icon" type="xs:string" use="optional"/>
             <xs:attribute name="width" type="xs:string" default="600"/>
             <xs:attribute name="height" type="xs:string" default="600"/>
             <xs:attribute name="transition" type="xs:string" use="required"/>


### PR DESCRIPTION
Add a button-icon attribute to container-dialog and dynamic-dialog.
This goes together with https://github.com/moqui/moqui-runtime/pull/25 that uses these attributes.