### PR TITLE
tenantAllowOverride=N should only reject change to other tenants not the tenant bind to the hostname.

### DIFF
--- a/framework/src/main/groovy/org/moqui/impl/context/ExecutionContextImpl.groovy
+++ b/framework/src/main/groovy/org/moqui/impl/context/ExecutionContextImpl.groovy
@@ -242,7 +242,8 @@ class ExecutionContextImpl implements ExecutionContext {
         ecfi.getEntityFacade(tenantId)
 
         // check for moqui.tenantAllowOverride flag set elsewhere
-        if (webFacade != null && webFacade.session.getAttribute("moqui.tenantAllowOverride") == "N")
+        if (webFacade != null && webFacade.session.getAttribute("moqui.tenantAllowOverride") == "N" &&
+                webFacade.session.getAttribute("moqui.tenantId") != tenantId)
             throw new BaseException("Tenant override is not allowed for host [${webFacade.session.getAttribute("moqui.tenantHostName")?:"Unknown"}].")
 
         activeTenantId = tenantId


### PR DESCRIPTION
I created a tenant and a `TenantHostDefault`, But I can open the login screen using that hostname. The following error occurs `Tenant override is not allowed for host [foobar]`. I think `tenantAllowOverride=N` should only prevent change to other tenantId. `initWebFacade` method change tenantId from  `DEFAULT` to the tenantId of this hostname. 