### PR TITLE
Localized field in view

### DIFF
--- a/framework/src/main/groovy/org/moqui/impl/entity/EntityDefinition.groovy
+++ b/framework/src/main/groovy/org/moqui/impl/entity/EntityDefinition.groovy
@@ -202,11 +202,7 @@ public class EntityDefinition {
                 if (fieldNode == null) throw new EntityException("In view-entity [${internalEntityName}] alias [${aliasNode.attribute("name")}] referred to field [${fieldName}] that does not exist on entity [${memberEd.internalEntityName}].")
                 if (!aliasNode.attribute("type")) aliasNode.attributes.put("type", fieldNode.attribute("type"))
                 if (fieldNode.attribute("is-pk") == "true") aliasNode.attributes.put("is-pk", "true")
-                if (fieldNode.attribute("enable-localization") == "true") {
-                    aliasNode.attributes.put("enable-localization", "true")
-                    aliasNode.attributes.put("view-original-entityName", memberEd.fullEntityName)
-                    aliasNode.attributes.put("view-original-fieldName", fieldName)
-                }
+                if (fieldNode.attribute("enable-localization") == "true") aliasNode.attributes.put("enable-localization", "true")
 
                 // add to aliases by field name by entity name
                 if (!memberEntityFieldAliases.containsKey(memberEd.getFullEntityName())) memberEntityFieldAliases.put(memberEd.getFullEntityName(), [:])
@@ -279,6 +275,11 @@ public class EntityDefinition {
         // no description? just use the first non-pk field: nonPkFields.get(0)
         // not any more, can be confusing... just return empty String
         return ""
+    }
+
+    String getMemberEntityName(String entityAlias) {
+        MNode memberEntityNode = memberEntityAliasMap.get(entityAlias)
+        return memberEntityNode?.attribute("entity-name")
     }
 
     boolean createOnly() { return createOnlyVal }
@@ -392,8 +393,6 @@ public class EntityDefinition {
         fi.isSimple = !fi.enableLocalization && !fi.isUserField
         fi.createOnly = fnAttrs.get('create-only') ? 'true'.equals(fnAttrs.get('create-only')) : ed.createOnly()
         fi.enableAuditLog = fieldNode.attribute('enable-audit-log') ?: ed.internalEntityNode.attribute('enable-audit-log')
-        fi.viewOriginalEntityName = fnAttrs.get('view-original-entityName')
-        fi.viewOriginalFieldName = fnAttrs.get('view-original-fieldName')
 
 
         if (ed.isViewEntity()) {

--- a/framework/src/main/groovy/org/moqui/impl/entity/EntityDefinition.groovy
+++ b/framework/src/main/groovy/org/moqui/impl/entity/EntityDefinition.groovy
@@ -202,6 +202,11 @@ public class EntityDefinition {
                 if (fieldNode == null) throw new EntityException("In view-entity [${internalEntityName}] alias [${aliasNode.attribute("name")}] referred to field [${fieldName}] that does not exist on entity [${memberEd.internalEntityName}].")
                 if (!aliasNode.attribute("type")) aliasNode.attributes.put("type", fieldNode.attribute("type"))
                 if (fieldNode.attribute("is-pk") == "true") aliasNode.attributes.put("is-pk", "true")
+                if (fieldNode.attribute("enable-localization") == "true") {
+                    aliasNode.attributes.put("enable-localization", "true")
+                    aliasNode.attributes.put("view-original-entityName", memberEd.fullEntityName)
+                    aliasNode.attributes.put("view-original-fieldName", fieldName)
+                }
 
                 // add to aliases by field name by entity name
                 if (!memberEntityFieldAliases.containsKey(memberEd.getFullEntityName())) memberEntityFieldAliases.put(memberEd.getFullEntityName(), [:])
@@ -387,6 +392,9 @@ public class EntityDefinition {
         fi.isSimple = !fi.enableLocalization && !fi.isUserField
         fi.createOnly = fnAttrs.get('create-only') ? 'true'.equals(fnAttrs.get('create-only')) : ed.createOnly()
         fi.enableAuditLog = fieldNode.attribute('enable-audit-log') ?: ed.internalEntityNode.attribute('enable-audit-log')
+        fi.viewOriginalEntityName = fnAttrs.get('view-original-entityName')
+        fi.viewOriginalFieldName = fnAttrs.get('view-original-fieldName')
+
 
         if (ed.isViewEntity()) {
             // NOTE: for view-entity the incoming fieldNode will actually be for an alias element

--- a/framework/src/main/groovy/org/moqui/impl/entity/EntityJavaUtil.java
+++ b/framework/src/main/groovy/org/moqui/impl/entity/EntityJavaUtil.java
@@ -497,6 +497,8 @@ public class EntityJavaUtil {
         public String defaultStr = null;
         public String javaType = null;
         public String enableAuditLog = null;
+        public String viewOriginalEntityName = null;
+        public String viewOriginalFieldName = null;
         public int typeValue = -1;
         public boolean isTextVeryLong = false;
         public boolean isPk = false;

--- a/framework/src/main/groovy/org/moqui/impl/entity/EntityJavaUtil.java
+++ b/framework/src/main/groovy/org/moqui/impl/entity/EntityJavaUtil.java
@@ -497,8 +497,6 @@ public class EntityJavaUtil {
         public String defaultStr = null;
         public String javaType = null;
         public String enableAuditLog = null;
-        public String viewOriginalEntityName = null;
-        public String viewOriginalFieldName = null;
         public int typeValue = -1;
         public boolean isTextVeryLong = false;
         public boolean isPk = false;

--- a/framework/src/main/groovy/org/moqui/impl/entity/EntityValueBase.groovy
+++ b/framework/src/main/groovy/org/moqui/impl/entity/EntityValueBase.groovy
@@ -228,24 +228,19 @@ abstract class EntityValueBase implements EntityValue {
                             if (ed.isViewEntity()) {
                                 entityName = fieldInfo.viewOriginalEntityName
                                 fieldName = fieldInfo.viewOriginalFieldName
-                                logger.warn("localizing field for ViewEntity ${ed.fullEntityName} field ${name}, using entityName: ${entityName}, fieldName: ${fieldName}, pkValue: ${pkValue}, locale: ${localeStr}")
+                                // logger.warn("localizing field for ViewEntity ${ed.fullEntityName} field ${name}, using entityName: ${entityName}, fieldName: ${fieldName}, pkValue: ${pkValue}, locale: ${localeStr}")
                             }
-							//lefFind.condition([entityName:ed.getFullEntityName(), fieldName:name, pkValue:pkValue, locale:localeStr] as Map<String, Object>)
                             EntityFind lefFind = getEntityFacadeImpl().find("moqui.basic.LocalizedEntityField")
-							lefFind.condition([entityName:entityName, fieldName:fieldName, pkValue:pkValue, locale:localeStr] as Map<String, Object>)
-							logger.warn("======== created lefFind: ${lefFind}")
+                            lefFind.condition([entityName:entityName, fieldName:fieldName, pkValue:pkValue, locale:localeStr] as Map<String, Object>)
                             EntityValue lefValue = lefFind.useCache(true).one()
                             if (lefValue != null) {
                                 String localized = (String) lefValue.localized
                                 StupidUtilities.addToMapInMap(name, localeStr, localized, localizedByLocaleByField)
-								logger.info("localized: ${localized}")
                                 return localized
                             }
-							logger.error("======== no result, trying shortened!")
                             // no result found, try with shortened locale
                             if (localeStr.contains("_")) {
                                 lefFind.condition("locale", localeStr.substring(0, localeStr.indexOf("_")))
-								logger.warn("======== new lefFind: ${lefFind}")
                                 lefValue = lefFind.useCache(true).one()
                                 if (lefValue != null) {
                                     String localized = (String) lefValue.localized
@@ -253,10 +248,8 @@ abstract class EntityValueBase implements EntityValue {
                                     return localized
                                 }
                             }
-							logger.error("======== no result!")
                             // no result found, try "default" locale
                             lefFind.condition("locale", "default")
-							logger.warn("======== new lefFind: ${lefFind}")
                             lefValue = lefFind.useCache(true).one()
                             if (lefValue != null) {
                                 String localized = (String) lefValue.localized

--- a/framework/src/main/groovy/org/moqui/impl/entity/EntityValueBase.groovy
+++ b/framework/src/main/groovy/org/moqui/impl/entity/EntityValueBase.groovy
@@ -206,21 +206,46 @@ abstract class EntityValueBase implements EntityValue {
 
                 if (!knownNoLocalized) {
                     List<String> pks = ed.getPkFieldNames()
+                    if (ed.isViewEntity()) {
+                        EntityDefinition memberEd = getEntityFacadeImpl().getEntityDefinition(fieldInfo.viewOriginalEntityName)
+                        pks = memberEd.getPkFieldNames()
+                    }
                     if (pks.size() == 1) {
-                        String pkValue = get(pks.get(0))
+						String pk = pks.get(0)
+						if (ed.isViewEntity()) {
+							pk = null
+							String entityAlias = ed.getFieldNode(name).attribute('entity-alias')
+							Map<String, String> pkToAliasMap = ed.getMePkFieldToAliasNameMap(entityAlias)
+							Set<String> pkSet = pkToAliasMap.keySet()
+							if (pkSet.size() == 1) pk = pkSet.iterator().next()
+							// logger.warn("======== changing pk to ${pk}")
+						}
+                        String pkValue = pk? get(pk): null
                         if (pkValue) {
                             // logger.warn("======== field ${name}:${internalValue} finding LocalizedEntityField, localizedByLocaleByField=${localizedByLocaleByField}")
+                            String entityName = ed.getFullEntityName()
+                            String fieldName = name
+                            if (ed.isViewEntity()) {
+                                entityName = fieldInfo.viewOriginalEntityName
+                                fieldName = fieldInfo.viewOriginalFieldName
+                                logger.warn("localizing field for ViewEntity ${ed.fullEntityName} field ${name}, using entityName: ${entityName}, fieldName: ${fieldName}, pkValue: ${pkValue}, locale: ${localeStr}")
+                            }
+							//lefFind.condition([entityName:ed.getFullEntityName(), fieldName:name, pkValue:pkValue, locale:localeStr] as Map<String, Object>)
                             EntityFind lefFind = getEntityFacadeImpl().find("moqui.basic.LocalizedEntityField")
-                            lefFind.condition([entityName:ed.getFullEntityName(), fieldName:name, pkValue:pkValue, locale:localeStr] as Map<String, Object>)
+							lefFind.condition([entityName:entityName, fieldName:fieldName, pkValue:pkValue, locale:localeStr] as Map<String, Object>)
+							logger.warn("======== created lefFind: ${lefFind}")
                             EntityValue lefValue = lefFind.useCache(true).one()
                             if (lefValue != null) {
                                 String localized = (String) lefValue.localized
                                 StupidUtilities.addToMapInMap(name, localeStr, localized, localizedByLocaleByField)
+								logger.info("localized: ${localized}")
                                 return localized
                             }
+							logger.error("======== no result, trying shortened!")
                             // no result found, try with shortened locale
                             if (localeStr.contains("_")) {
                                 lefFind.condition("locale", localeStr.substring(0, localeStr.indexOf("_")))
+								logger.warn("======== new lefFind: ${lefFind}")
                                 lefValue = lefFind.useCache(true).one()
                                 if (lefValue != null) {
                                     String localized = (String) lefValue.localized
@@ -228,8 +253,10 @@ abstract class EntityValueBase implements EntityValue {
                                     return localized
                                 }
                             }
+							logger.error("======== no result!")
                             // no result found, try "default" locale
                             lefFind.condition("locale", "default")
+							logger.warn("======== new lefFind: ${lefFind}")
                             lefValue = lefFind.useCache(true).one()
                             if (lefValue != null) {
                                 String localized = (String) lefValue.localized

--- a/framework/src/main/groovy/org/moqui/impl/entity/EntityValueBase.groovy
+++ b/framework/src/main/groovy/org/moqui/impl/entity/EntityValueBase.groovy
@@ -222,8 +222,7 @@ abstract class EntityValueBase implements EntityValue {
                             pk = null
                             Map<String, String> pkToAliasMap = ed.getMePkFieldToAliasNameMap(aliasNode.attribute('entity-alias'))
                             Set<String> pkSet = pkToAliasMap.keySet()
-                            if (pkSet.size() == 1) pk = pkSet.iterator().next()
-                            // logger.warn("======== changing pk to ${pk}")
+                            if (pkSet.size() == 1) pk = pkToAliasMap.get(pkSet.iterator().next())
                         }
                         String pkValue = pk? get(pk): null
                         if (pkValue) {

--- a/framework/src/main/groovy/org/moqui/impl/entity/EntityValueBase.groovy
+++ b/framework/src/main/groovy/org/moqui/impl/entity/EntityValueBase.groovy
@@ -205,29 +205,34 @@ abstract class EntityValueBase implements EntityValue {
                 }
 
                 if (!knownNoLocalized) {
-                    List<String> pks = ed.getPkFieldNames()
+                    List<String> pks
+                    MNode aliasNode = null
+                    String memberEntityName = null
                     if (ed.isViewEntity()) {
-                        EntityDefinition memberEd = getEntityFacadeImpl().getEntityDefinition(fieldInfo.viewOriginalEntityName)
+                        aliasNode = ed.getFieldNode(name)
+                        memberEntityName = ed.getMemberEntityName(aliasNode.attribute('entity-alias'))
+                        EntityDefinition memberEd = getEntityFacadeImpl().getEntityDefinition(memberEntityName)
                         pks = memberEd.getPkFieldNames()
+                    } else {
+                        pks = ed.getPkFieldNames()
                     }
                     if (pks.size() == 1) {
-						String pk = pks.get(0)
-						if (ed.isViewEntity()) {
-							pk = null
-							String entityAlias = ed.getFieldNode(name).attribute('entity-alias')
-							Map<String, String> pkToAliasMap = ed.getMePkFieldToAliasNameMap(entityAlias)
-							Set<String> pkSet = pkToAliasMap.keySet()
-							if (pkSet.size() == 1) pk = pkSet.iterator().next()
-							// logger.warn("======== changing pk to ${pk}")
-						}
+                        String pk = pks.get(0)
+                        if (ed.isViewEntity()) {
+                            pk = null
+                            Map<String, String> pkToAliasMap = ed.getMePkFieldToAliasNameMap(aliasNode.attribute('entity-alias'))
+                            Set<String> pkSet = pkToAliasMap.keySet()
+                            if (pkSet.size() == 1) pk = pkSet.iterator().next()
+                            // logger.warn("======== changing pk to ${pk}")
+                        }
                         String pkValue = pk? get(pk): null
                         if (pkValue) {
                             // logger.warn("======== field ${name}:${internalValue} finding LocalizedEntityField, localizedByLocaleByField=${localizedByLocaleByField}")
                             String entityName = ed.getFullEntityName()
                             String fieldName = name
                             if (ed.isViewEntity()) {
-                                entityName = fieldInfo.viewOriginalEntityName
-                                fieldName = fieldInfo.viewOriginalFieldName
+                                entityName = memberEntityName
+                                fieldName = aliasNode.attribute('field')?: aliasNode.attribute('name')
                                 // logger.warn("localizing field for ViewEntity ${ed.fullEntityName} field ${name}, using entityName: ${entityName}, fieldName: ${fieldName}, pkValue: ${pkValue}, locale: ${localeStr}")
                             }
                             EntityFind lefFind = getEntityFacadeImpl().find("moqui.basic.LocalizedEntityField")


### PR DESCRIPTION
When a field with enable-localization=true is an alias in a view, it would be expected to be localized in the view as well. These changes do exactly this, provided that the PK of the member entity with the localized field is also included in the view.
As I'm not quite familiarized with the internal workings of moqui-framework the changes could surely be improved, so if there are suggestions, they are welcome.