### PR TITLE
Format fraction digits according to currency

### DIFF
--- a/framework/src/main/groovy/org/moqui/impl/context/L10nFacadeImpl.java
+++ b/framework/src/main/groovy/org/moqui/impl/context/L10nFacadeImpl.java
@@ -98,6 +98,11 @@ public class L10nFacadeImpl implements L10nFacade {
     }
 
     @Override
+    public String formatCurrency(Object amount, String uomId) {
+        return formatCurrency(amount, uomId, null);
+    }
+
+    @Override
     public String formatCurrency(Object amount, String uomId, Integer fractionDigits) {
         return formatCurrency(amount, uomId, fractionDigits, getLocale());
     }
@@ -112,10 +117,11 @@ public class L10nFacadeImpl implements L10nFacade {
             }
         }
 
-        if (fractionDigits == null) fractionDigits = 2;
         if (locale == null) locale = getLocale();
         NumberFormat nf = NumberFormat.getCurrencyInstance(locale);
-        if (uomId != null && uomId.length() > 0) nf.setCurrency(Currency.getInstance(uomId));
+        Currency currency = Currency.getInstance(uomId);
+        if (fractionDigits == null) fractionDigits = currency.getDefaultFractionDigits();
+        if (uomId != null && uomId.length() > 0) nf.setCurrency(currency);
         nf.setMaximumFractionDigits(fractionDigits);
         nf.setMinimumFractionDigits(fractionDigits);
         return nf.format(amount);

--- a/framework/src/main/java/org/moqui/context/L10nFacade.java
+++ b/framework/src/main/java/org/moqui/context/L10nFacade.java
@@ -35,10 +35,12 @@ public interface L10nFacade {
     /** Format currency amount for user to view.
      * @param amount An object representing the amount, should be a subclass of Number.
      * @param uomId The uomId (ISO currency code), required.
-     * @param fractionDigits Number of digits after the decimal point to display. If null defaults to 2.
+     * @param fractionDigits Number of digits after the decimal point to display. If null defaults to number defined
+     *                       by java.util.Currency.defaultFractionDigits() for the current or specified locale.
      * @return The formatted currency amount.
      */
     String formatCurrency(Object amount, String uomId, Integer fractionDigits);
+    String formatCurrency(Object amount, String uomId);
     String formatCurrency(Object amount, String uomId, Integer fractionDigits, Locale locale);
 
     /** Format a Number, Timestamp, Date, Time, or Calendar object using the given format string. If no format string

--- a/framework/src/main/java/org/moqui/context/L10nFacade.java
+++ b/framework/src/main/java/org/moqui/context/L10nFacade.java
@@ -36,7 +36,7 @@ public interface L10nFacade {
      * @param amount An object representing the amount, should be a subclass of Number.
      * @param uomId The uomId (ISO currency code), required.
      * @param fractionDigits Number of digits after the decimal point to display. If null defaults to number defined
-     *                       by java.util.Currency.defaultFractionDigits() for the current or specified locale.
+     *                       by java.util.Currency.defaultFractionDigits() for the specified currency in uomId.
      * @return The formatted currency amount.
      */
     String formatCurrency(Object amount, String uomId, Integer fractionDigits);


### PR DESCRIPTION
Use the default fractionDigits number to format currencies. This way we do not specify them hardwired in the screens, but let the framework figure out how to format.

If this is OK, it would also be necessary to provide a way to format the text-line tags containing currency values, currently explicitly formatted in screens using "#0.00" that also should depend on the currency of the value being displayed.
As they should not contain the symbol prefix nor thousands separators to facilitate editing, they should be formatted using other methods or adding a parameter indicating whether to use thousands separators and prefixes.