### PR TITLE
Rest client https

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -45,7 +45,7 @@ Written in 2015 by Sam Hamilton - samhamilton
 Written in 2015 by Leonardo Carvalho - CarvalhoLeonardo
 Written in 2015 by Swapnil M Mane - swapnilmmane
 Written in 2015 by Anton Akhiar - akhiar
-Writter in 2015-2015 by Jens Hardings - jenshp
+Writter in 2015-2016 by Jens Hardings - jenshp
 Writter in 2016 by Shifeng Zhang - zhangshifeng
 Written in 2016 by Scott Gray - lektran
 Written in 2016 by Mark Haney - mphaney
@@ -80,7 +80,7 @@ Written in 2015 by Jimmy Shen - shendepu
 Written in 2015-2016 by Sam Hamilton - samhamilton
 Written in 2015 by Leonardo Carvalho - CarvalhoLeonardo
 Written in 2015 by Anton Akhiar - akhiar
-Writter in 2015-2015 by Jens Hardings - jenshp
+Writter in 2015-2016 by Jens Hardings - jenshp
 Writter in 2016 by Shifeng Zhang - zhangshifeng
 Wrttien in 2016 by Scott Gray - lektran
 Written in 2016 by Mark Haney - mphaney

--- a/framework/src/main/groovy/org/moqui/impl/service/RestClientImpl.groovy
+++ b/framework/src/main/groovy/org/moqui/impl/service/RestClientImpl.groovy
@@ -26,6 +26,7 @@ import org.eclipse.jetty.client.util.BasicAuthentication
 import org.eclipse.jetty.client.util.StringContentProvider
 import org.eclipse.jetty.http.HttpField
 import org.eclipse.jetty.http.HttpHeader
+import org.eclipse.jetty.util.ssl.SslContextFactory
 import org.moqui.BaseException
 import org.moqui.impl.StupidUtilities
 import org.moqui.impl.context.ExecutionContextFactoryImpl
@@ -129,7 +130,8 @@ class RestClientImpl implements RestClient {
 
         ContentResponse response = null
 
-        HttpClient httpClient = new HttpClient()
+        SslContextFactory sslContextFactory = new SslContextFactory();
+        HttpClient httpClient = new HttpClient(sslContextFactory)
         httpClient.start()
 
         try {


### PR DESCRIPTION
When using RestClient to connect to another server using an https URL (or even being redirected to https when originally fetching an http URL), it fails with an ExecutionException due to some NulPointerException.
The cause is that one has to enable https capability explicitly for the underlying Jetty HttpRequest being able to do https.
This pull request fixes this.