### PR TITLE
Use localized service to define regions in drop-down, fall back to de…

### DIFF
--- a/framework/entity/BasicEntities.xml
+++ b/framework/entity/BasicEntities.xml
@@ -149,6 +149,7 @@ along with this software (see the LICENSE.md file). If not, see
             <moqui.basic.Enumeration description="Geo Group Member" enumId="GAT_GROUP_MEMBER" enumTypeId="GeoAssocType"/>
             <moqui.basic.Enumeration description="Region of a Larger Geo" enumId="GAT_REGIONS" enumTypeId="GeoAssocType"/>
             <moqui.basic.Enumeration description="Administrative City" enumId="GAT_COUNTY_SEAT" enumTypeId="GeoAssocType"/>
+            <moqui.basic.Enumeration description="Division of Region for PostalAddress Purposes" enumId="GAT_POSTALADDR_DIV" enumTypeId="GeoAssocType"/>
         </seed-data>
     </entity>
     <view-entity entity-name="GeoAssocAndToDetail" package="moqui.basic">
@@ -195,19 +196,6 @@ along with this software (see the LICENSE.md file). If not, see
         <field name="pkValue" type="text-medium" is-pk="true"/>
         <field name="locale" type="text-short" is-pk="true"/>
         <field name="localized" type="text-long"/>
-    </entity>
-    <entity entity-name="LocalizedService" package="moqui.basic" use="configuration" authorize-skip="view" cache="true">
-        <field name="serviceTypeEnumId" type="id" is-pk="true"/>
-        <field name="locale" type="text-short" is-pk="true"/>
-        <field name="serviceName" type="text-short"/>
-        <relationship type="one" title="LocalizedServiceType" related="moqui.basic.Enumeration" short-alias="type">
-            <key-map field-name="serviceTypeEnumId"/></relationship>
-        <seed-data>
-            <moqui.basic.EnumerationType enumTypeId="LocalizedServiceType"
-                                         description="Services that can be defined for each specific localization"/>
-            <moqui.basic.Enumeration enumTypeId="LocalizedServiceType" enumId="LstGeoRegionsForDropDown"
-                description="List of regions to display in a drop-down when selecting a containing region"/>
-        </seed-data>
     </entity>
 
     <!-- ========== Status ========== -->

--- a/framework/entity/BasicEntities.xml
+++ b/framework/entity/BasicEntities.xml
@@ -196,6 +196,19 @@ along with this software (see the LICENSE.md file). If not, see
         <field name="locale" type="text-short" is-pk="true"/>
         <field name="localized" type="text-long"/>
     </entity>
+    <entity entity-name="LocalizedService" package="moqui.basic" use="configuration" authorize-skip="view" cache="true">
+        <field name="serviceTypeEnumId" type="id" is-pk="true"/>
+        <field name="locale" type="text-short" is-pk="true"/>
+        <field name="serviceName" type="text-short"/>
+        <relationship type="one" title="LocalizedServiceType" related="moqui.basic.Enumeration" short-alias="type">
+            <key-map field-name="serviceTypeEnumId"/></relationship>
+        <seed-data>
+            <moqui.basic.EnumerationType enumTypeId="LocalizedServiceType"
+                                         description="Services that can be defined for each specific localization"/>
+            <moqui.basic.Enumeration enumTypeId="LocalizedServiceType" enumId="LstGeoRegionsForDropDown"
+                description="List of regions to display in a drop-down when selecting a containing region"/>
+        </seed-data>
+    </entity>
 
     <!-- ========== Status ========== -->
     <entity entity-name="StatusItem" package="moqui.basic" use="configuration" short-alias="statuses" cache="true">

--- a/framework/service/org/moqui/impl/BasicServices.xml
+++ b/framework/service/org/moqui/impl/BasicServices.xml
@@ -25,13 +25,22 @@ along with this software (see the LICENSE.md file). If not, see
         <actions>
             <set field="resultList" from="[]"/>
             <if condition="geoId">
-                <entity-find entity-name="moqui.basic.GeoAssocAndToDetail" list="geoList">
-                    <econdition field-name="geoId"/><econdition field-name="geoAssocTypeEnumId"/>
-                    <econdition field-name="geoTypeEnumId" ignore-if-empty="true"/>
-                    <order-by field-name="geoName"/>
+                <entity-find entity-name="moqui.basic.LocalizedService" list="localizedServices">
+                    <econdition field-name="serviceTypeEnumId" value="LstGeoRegionsForDropDown"/>
                 </entity-find>
-                <script>for (geo in geoList) resultList.add([geoId:geo.toGeoId, label:(geo.geoCodeAlpha2 ? geo.geoCodeAlpha2 + ' - ' : '') + geo.geoName,
-                        geoName:geo.geoName, geoCodeAlpha2:geo.geoCodeAlpha2])</script>
+                <iterate list="localizedServices" entry="ls">
+                    <service-call name="${ls.serviceName}" in-map="context" out-map="lsr"/>
+                    <script>resultList += lsr.resultList</script>
+                </iterate>
+                <if condition="resultList.size() == 0">
+                    <entity-find entity-name="moqui.basic.GeoAssocAndToDetail" list="geoList">
+                        <econdition field-name="geoId"/><econdition field-name="geoAssocTypeEnumId"/>
+                        <econdition field-name="geoTypeEnumId" ignore-if-empty="true"/>
+                        <order-by field-name="geoName"/>
+                    </entity-find>
+                    <script>for (geo in geoList) resultList.add([geoId:geo.toGeoId, label:(geo.geoCodeAlpha2 ? geo.geoCodeAlpha2 + ' - ' : '') + geo.geoName,
+                            geoName:geo.geoName, geoCodeAlpha2:geo.geoCodeAlpha2])</script>
+                </if>
             </if>
         </actions>
     </service>

--- a/framework/service/org/moqui/impl/BasicServices.xml
+++ b/framework/service/org/moqui/impl/BasicServices.xml
@@ -18,29 +18,28 @@ along with this software (see the LICENSE.md file). If not, see
     <service verb="get" noun="GeoRegionsForDropDown" allow-remote="true">
         <in-parameters>
             <parameter name="geoId"/>
-            <parameter name="geoAssocTypeEnumId" default-value="GAT_REGIONS"/>
+            <parameter name="geoAssocTypeEnumId" default-value="GAT_POSTALADDR_DIV"/>
             <parameter name="geoTypeEnumId"/>
         </in-parameters>
         <out-parameters><parameter name="resultList" type="List"><parameter name="result" type="Map"/></parameter></out-parameters>
         <actions>
             <set field="resultList" from="[]"/>
             <if condition="geoId">
-                <entity-find entity-name="moqui.basic.LocalizedService" list="localizedServices">
-                    <econdition field-name="serviceTypeEnumId" value="LstGeoRegionsForDropDown"/>
+                <entity-find entity-name="moqui.basic.GeoAssocAndToDetail" list="geoList">
+                    <econdition field-name="geoId"/><econdition field-name="geoAssocTypeEnumId"/>
+                    <econdition field-name="geoTypeEnumId" ignore-if-empty="true"/>
+                    <order-by field-name="geoName"/>
                 </entity-find>
-                <iterate list="localizedServices" entry="ls">
-                    <service-call name="${ls.serviceName}" in-map="context" out-map="lsr"/>
-                    <script>resultList += lsr.resultList</script>
-                </iterate>
-                <if condition="resultList.size() == 0">
+                <if condition="geoList.size() == 0">
+                    <set field="geoAssocTypeEnumId" value="GAT_REGIONS"/>
                     <entity-find entity-name="moqui.basic.GeoAssocAndToDetail" list="geoList">
                         <econdition field-name="geoId"/><econdition field-name="geoAssocTypeEnumId"/>
                         <econdition field-name="geoTypeEnumId" ignore-if-empty="true"/>
                         <order-by field-name="geoName"/>
                     </entity-find>
-                    <script>for (geo in geoList) resultList.add([geoId:geo.toGeoId, label:(geo.geoCodeAlpha2 ? geo.geoCodeAlpha2 + ' - ' : '') + geo.geoName,
-                            geoName:geo.geoName, geoCodeAlpha2:geo.geoCodeAlpha2])</script>
                 </if>
+                <script>for (geo in geoList) resultList.add([geoId:geo.toGeoId, label:(geo.geoCodeAlpha2 ? geo.geoCodeAlpha2 + ' - ' : '') + geo.geoName,
+                        geoName:geo.geoName, geoCodeAlpha2:geo.geoCodeAlpha2])</script>
             </if>
         </actions>
     </service>


### PR DESCRIPTION
A way to add localized services, as a way to have localizations be able to redefine certain behaviours through configurations. This is useful for example in the case of defining how to determine the geoId options to choose from based on the country, and have the result be country-specific.
An example that uses this functionality is visible at https://github.com/Moitcl/moqui-chile