### PR TITLE
allow -Pconf= to override configuration file while using gradle

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,12 +1,12 @@
 /*
  * This software is in the public domain under CC0 1.0 Universal plus a
  * Grant of Patent License.
- * 
+ *
  * To the extent possible under law, the author(s) have dedicated all
  * copyright and related and neighboring rights to this software to the
  * public domain worldwide. This software is distributed without any
  * warranty.
- * 
+ *
  * You should have received a copy of the CC0 Public Domain Dedication
  * along with this software (see the LICENSE.md file). If not, see
  * <http://creativecommons.org/publicdomain/zero/1.0/>.
@@ -29,8 +29,8 @@ def plusRuntimeName = 'moqui-plus-runtime.war'
 def execTempDir = 'execwartmp'
 def moquiRuntime = 'runtime'
 
-def moquiConfDev = 'conf/MoquiDevConf.xml'
-def moquiConfProduction = 'conf/MoquiProductionConf.xml'
+def moquiConfDev = project.properties['conf'] ?: 'conf/MoquiDevConf.xml'
+def moquiConfProduction = project.properties['conf'] ?: 'conf/MoquiProductionConf.xml'
 
 def allCleanTasks = getTasksByName('clean', true)
 def allBuildTasks = getTasksByName('build', true)


### PR DESCRIPTION
In [Running and Deployment Instructions](http://www.moqui.org/framework/docs/RunDeploy.html#CommonAlternateSpecifyaConfigurationFileonCommandLine) a  _Common Alternate_ to provide a configuration file at the command line is provided for `java -jar moqui.war conf=xyz`

this PR allows for the same for the `gradle task`
`./gradlew runProduction -Pconf=xyz`

I don't know that this is the best practice, but since the option is there when running the war file directly, it might as well be there when running the `gradle task`