### PR TITLE
add WEB-INF/classes so init properties are picked up

### DIFF
--- a/framework/src/start/java/MoquiStart.java
+++ b/framework/src/start/java/MoquiStart.java
@@ -1,12 +1,12 @@
 /*
  * This software is in the public domain under CC0 1.0 Universal plus a
  * Grant of Patent License.
- * 
+ *
  * To the extent possible under law, the author(s) have dedicated all
  * copyright and related and neighboring rights to this software to the
  * public domain worldwide. This software is distributed without any
  * warranty.
- * 
+ *
  * You should have received a copy of the CC0 Public Domain Dedication
  * along with this software (see the LICENSE.md file). If not, see
  * <http://creativecommons.org/publicdomain/zero/1.0/>.
@@ -342,7 +342,7 @@ public class MoquiStart {
 
     private static void initSystemProperties(StartClassLoader cl, boolean useProperties) throws IOException {
         Properties moquiInitProperties = new Properties();
-        URL initProps = cl.getResource("MoquiInit.properties");
+        URL initProps = cl.getResource("WEB-INF/classes/MoquiInit.properties");
         if (initProps != null) { InputStream is = initProps.openStream(); moquiInitProperties.load(is); is.close(); }
 
         // before doing anything else make sure the moqui.runtime system property exists (needed for config of various things)


### PR DESCRIPTION
Without looking further into it, `StartClassLoader.getResource("resourceName")` needs `resourceName` to be prefixed with `WEB-INF/classes` in order to pull the properties from `${moquiBase}/MoquiInit.properties`