### PR TITLE
Conversion purpose

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -45,7 +45,7 @@ Written in 2015 by Sam Hamilton - samhamilton
 Written in 2015 by Leonardo Carvalho - CarvalhoLeonardo
 Written in 2015 by Swapnil M Mane - swapnilmmane
 Written in 2015 by Anton Akhiar - akhiar
-Writter in 2015-2016 by Jens Hardings - jenshp
+Writter in 2015-2017 by Jens Hardings - jenshp
 Writter in 2016 by Shifeng Zhang - zhangshifeng
 Written in 2016 by Scott Gray - lektran
 Written in 2016 by Mark Haney - mphaney

--- a/framework/entity/BasicEntities.xml
+++ b/framework/entity/BasicEntities.xml
@@ -352,9 +352,16 @@ along with this software (see the LICENSE.md file). If not, see
                 direction the offset is subtracted first, then divided by the factor.
             </description>
         </field>
+        <field name="purposeEnumId" type="id"/>
         <relationship type="one" related="moqui.basic.Uom" short-alias="uom"/>
         <relationship type="one" title="To" related="moqui.basic.Uom" short-alias="toUom">
             <key-map field-name="toUomId" related="uomId"/></relationship>
+        <relationship type="one" related="moqui.basic.Enumeration" title="UomConversionPurposeType">
+            <key-map field-name="purposeEnumId" related="enumId"/>
+        </relationship>
+        <seed-data>
+            <moqui.basic.EnumerationType description="Uom Conversion Purpose Type" enumTypeId="UomConversionPurposeType"/>
+        </seed-data>
     </entity>
     <view-entity entity-name="UomConversionAndToDetail" package="moqui.basic">
         <member-entity entity-alias="UOMC" entity-name="moqui.basic.UomConversion"/>


### PR DESCRIPTION
Added a purposeEnumId field to UomConversion. This is useful e.g. when having more than one possible conversion according to the use case, which can happen most of all in currency conversions, like some "official" conversion rate that can differ from the "market", "internal" or "contractual" conversion rates in value or update frequency.