### PR TITLE
Add is-aggregate attribute to specify if a function is an aggregate function

### DIFF
--- a/framework/src/main/groovy/org/moqui/impl/entity/FieldInfo.java
+++ b/framework/src/main/groovy/org/moqui/impl/entity/FieldInfo.java
@@ -136,7 +136,9 @@ public class FieldInfo {
                 tempMembEntNode = ed.memberEntityAliasMap.get(singleEntityAlias);
             }
             memberEntityNode = tempMembEntNode;
-            hasAggregateFunction = aggFunctions.contains(fieldNode.attribute("function"));
+            String isAggregateAttr = fieldNode.attribute("is-aggregate");
+            hasAggregateFunction = isAggregateAttr != null ? "true".equalsIgnoreCase(isAggregateAttr) :
+                    aggFunctions.contains(fieldNode.attribute("function"));
         } else {
             memberEntityNode = null;
             directMemberEntityNode = null;

--- a/framework/xsd/entity-definition-2.1.xsd
+++ b/framework/xsd/entity-definition-2.1.xsd
@@ -454,6 +454,11 @@ along with this software (see the LICENSE.md file). If not, see
             <xs:attribute name="name" type="name-field" use="required"/>
             <xs:attribute name="field" type="name-field"/>
             <xs:attribute name="function" type="aggregate-function"/>
+            <xs:attribute name="is-aggregate" type="boolean">
+                <xs:annotation><xs:documentation>Specify if the function is an aggregate function.
+                    If unspecified determined automatically from function attribute.
+                </xs:documentation></xs:annotation>
+            </xs:attribute>
             <xs:attribute name="type" type="field-type-options" use="optional">
                 <xs:annotation><xs:documentation>Normally determined automatically from the entity field it is based on
                     but needs to be specified for complex-alias with a function if you want something other than


### PR DESCRIPTION
When not specified determined by if function is in the aggregate functions list.
Allow use other aggregate functions supported by database.