### PR TITLE
Format BigDecimal values in hidden fields and drop-down options according to locale

### DIFF
--- a/framework/src/main/groovy/org/moqui/impl/screen/ScreenForm.groovy
+++ b/framework/src/main/groovy/org/moqui/impl/screen/ScreenForm.groovy
@@ -1001,6 +1001,8 @@ class ScreenForm {
                             if (keyAttr != null || textAttr != null) {
                                 addFieldOption(options, fieldNode, childNode, [entry:listOption], ec)
                             } else {
+                                if (listOption instanceof BigDecimal)
+                                    listOption = ec.l10n.format(listOption, null)
                                 String loString = ObjectUtilities.toPlainString(listOption)
                                 if (loString != null) options.put(loString, loString)
                             }

--- a/framework/src/main/groovy/org/moqui/impl/screen/ScreenRenderImpl.groovy
+++ b/framework/src/main/groovy/org/moqui/impl/screen/ScreenRenderImpl.groovy
@@ -1281,6 +1281,9 @@ class ScreenRenderImpl implements ScreenRender {
     String getFieldValuePlainString(MNode fieldNodeWrapper, String defaultValue) {
         // NOTE: defaultValue is handled below so that for a plain string it is not run through expand
         Object obj = getFieldValue(fieldNodeWrapper, "")
+        if (obj instanceof BigDecimal) {
+            obj = ec.l10nFacade.format(obj, null)
+        }
         if (ObjectUtilities.isEmpty(obj) && defaultValue != null && defaultValue.length() > 0)
             return ec.resourceFacade.expandNoL10n(defaultValue, "")
         return ObjectUtilities.toPlainString(obj)


### PR DESCRIPTION
When received and processed in a transition, these field's values will be treated as if in user's locale, so this change is required for a DB roundtrip through the browser to work smoothly. This solves the server part of https://github.com/moqui/moqui-framework/issues/49
It affects the value of hidden fields and options, as well as the current value in drop-down fields. The developer should, however, be locale aware if using the expandable key and text attributes of tags like entity-option and list-option, adding "${ec.l10n.format(keyName, null)} instead of just "${keyName}" for the code to work using a locale with comma as decimal separator. Making this aspect transparent to the developer would require to modify the behavior of ResourceFacade.expand(...) to make the transformation into the locale-aware format, which could affect other uses of that method.