### PR TITLE
Changed field "original" of entity moqui.basic.LocalizedMessage to text-long

### DIFF
--- a/framework/entity/BasicEntities.xml
+++ b/framework/entity/BasicEntities.xml
@@ -202,7 +202,7 @@ along with this software (see the LICENSE.md file). If not, see
 
     <!-- ========== Localized ========== -->
     <entity entity-name="LocalizedMessage" package="moqui.basic" use="configuration" authorize-skip="view" cache="true">
-        <field name="original" type="text-medium" is-pk="true"/>
+        <field name="original" type="text-long" is-pk="true"/>
         <field name="locale" type="text-short" is-pk="true"/>
         <field name="localized" type="text-long"/>
     </entity>


### PR DESCRIPTION
Several strings needed to translate exceed 255 characters, in particular the validation messages in mantle.order.OrderInfoServices.check#OrderPreApprove.