### PR TITLE
subscreens-item parameter child node support

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -51,6 +51,7 @@ Written in 2016 by Scott Gray - lektran
 Written in 2016 by Mark Haney - mphaney
 Writter in 2016 by Qiushi Yan - yanqiushi
 Written in 2017 by Oleg Andrieiev - oandreyev
+Written in 2017 by Christian Carlow - ccarlow
 
 ===========================================================================
 

--- a/AUTHORS
+++ b/AUTHORS
@@ -88,3 +88,4 @@ Wrttien in 2016 by Scott Gray - lektran
 Written in 2016 by Mark Haney - mphaney
 Writter in 2016 by Qiushi Yan - yanqiushi
 Written in 2017 by Oleg Andrieiev - oandreyev
+Written in 2017 by Christian Carlow - ccarlow

--- a/framework/data/UnitData.xml
+++ b/framework/data/UnitData.xml
@@ -64,6 +64,10 @@ along with this software (see the LICENSE.md file). If not, see
     <moqui.basic.Uom abbreviation="score" description="Score" uomId="TF_score" uomTypeEnumId="UT_TIME_FREQ_MEASURE"/>
     <moqui.basic.Uom abbreviation="century" description="Century" uomId="TF_century" uomTypeEnumId="UT_TIME_FREQ_MEASURE"/>
     <moqui.basic.Uom abbreviation="millenium" description="Millenium" uomId="TF_millenium" uomTypeEnumId="UT_TIME_FREQ_MEASURE"/>
+    <moqui.basic.Uom abbreviation="yearmonth" description="Month of year" uomId="TF_yr_mon" uomTypeEnumId="UT_TIME_FREQ_MEASURE"/>
+    <moqui.basic.Uom abbreviation="weekday" description="Day of week" uomId="TF_wk_day" uomTypeEnumId="UT_TIME_FREQ_MEASURE"/>
+    <moqui.basic.Uom abbreviation="monthday" description="Day of month" uomId="TF_mon_day" uomTypeEnumId="UT_TIME_FREQ_MEASURE"/>
+    <moqui.basic.Uom abbreviation="monthweekday" description="Day of week in month" uomId="TF_mon_wk_day" uomTypeEnumId="UT_TIME_FREQ_MEASURE"/>
 
     <moqui.basic.UomConversion uomConversionId="TIME_FREQ_s_ms" uomId="TF_s" toUomId="TF_ms" conversionFactor="1000"/>
     <moqui.basic.UomConversion uomConversionId="TIME_FREQ_min_s" uomId="TF_min" toUomId="TF_s" conversionFactor="60"/>

--- a/framework/data/UnitData.xml
+++ b/framework/data/UnitData.xml
@@ -64,10 +64,6 @@ along with this software (see the LICENSE.md file). If not, see
     <moqui.basic.Uom abbreviation="score" description="Score" uomId="TF_score" uomTypeEnumId="UT_TIME_FREQ_MEASURE"/>
     <moqui.basic.Uom abbreviation="century" description="Century" uomId="TF_century" uomTypeEnumId="UT_TIME_FREQ_MEASURE"/>
     <moqui.basic.Uom abbreviation="millenium" description="Millenium" uomId="TF_millenium" uomTypeEnumId="UT_TIME_FREQ_MEASURE"/>
-    <moqui.basic.Uom abbreviation="yearmonth" description="Month of year" uomId="TF_yr_mon" uomTypeEnumId="UT_TIME_FREQ_MEASURE"/>
-    <moqui.basic.Uom abbreviation="weekday" description="Day of week" uomId="TF_wk_day" uomTypeEnumId="UT_TIME_FREQ_MEASURE"/>
-    <moqui.basic.Uom abbreviation="monthday" description="Day of month" uomId="TF_mon_day" uomTypeEnumId="UT_TIME_FREQ_MEASURE"/>
-    <moqui.basic.Uom abbreviation="monthweekday" description="Day of week in month" uomId="TF_mon_wk_day" uomTypeEnumId="UT_TIME_FREQ_MEASURE"/>
 
     <moqui.basic.UomConversion uomConversionId="TIME_FREQ_s_ms" uomId="TF_s" toUomId="TF_ms" conversionFactor="1000"/>
     <moqui.basic.UomConversion uomConversionId="TIME_FREQ_min_s" uomId="TF_min" toUomId="TF_s" conversionFactor="60"/>

--- a/framework/src/main/groovy/org/moqui/impl/screen/ScreenDefinition.groovy
+++ b/framework/src/main/groovy/org/moqui/impl/screen/ScreenDefinition.groovy
@@ -1005,6 +1005,7 @@ class ScreenDefinition {
         protected boolean menuInclude
         protected Class disableWhenGroovy = null
         protected String userGroupId = null
+        protected Map<String, ScreenDefinition.ParameterItem> parameterByName = new HashMap<>()
 
         SubscreensItem(String name, String location, MNode screen, ScreenDefinition parentScreen) {
             this.parentScreen = parentScreen
@@ -1022,6 +1023,13 @@ class ScreenDefinition {
             menuTitle = subscreensItem.attribute("menu-title") ?: getDefaultTitle()
             menuIndex = subscreensItem.attribute("menu-index") ? (subscreensItem.attribute("menu-index") as Integer) : null
             menuInclude = (!subscreensItem.attribute("menu-include") || subscreensItem.attribute("menu-include") == "true")
+
+            for (MNode parameterNode in subscreensItem.children("parameter")) {
+                ScreenDefinition.ParameterItem parmItem = new ScreenDefinition.ParameterItem(parameterNode, location, parentScreen.sfi.ecfi)
+                parameterByName.put(parameterNode.attribute("name"), parmItem)
+                if (parmItem.required) hasRequired = true
+            }
+
 
             if (subscreensItem.attribute("disable-when")) disableWhenGroovy = parentScreen.sfi.ecfi.getGroovyClassLoader()
                     .parseClass(subscreensItem.attribute("disable-when"), "${parentScreen.location}.subscreens_item_${name}.disable_when")
@@ -1048,6 +1056,7 @@ class ScreenDefinition {
         String getLocation() { return location }
         String getMenuTitle() { return menuTitle }
         Integer getMenuIndex() { return menuIndex }
+        Map<String, ParameterItem> getParameterMap() { return parameterByName }
         boolean getMenuInclude() { return menuInclude }
         boolean getDisable(ExecutionContext ec) {
             if (disableWhenGroovy == null) return false

--- a/framework/src/main/groovy/org/moqui/impl/screen/ScreenRenderImpl.groovy
+++ b/framework/src/main/groovy/org/moqui/impl/screen/ScreenRenderImpl.groovy
@@ -1583,6 +1583,14 @@ class ScreenRenderImpl implements ScreenRender {
                 // build this subscreen's pathWithParams
                 String pathWithParams = "/" + sui.preTransitionPathNameList.join("/")
                 Map<String, String> parmMap = screenUrlInstance.getParameterMap()
+
+                for (ScreenDefinition.ParameterItem pi in subscreensItem.getParameterMap().values()) {
+                    Object value = pi.getValue(ec)
+                    String valueStr = ObjectUtilities.toPlainString(value)
+                    if (valueStr != null && valueStr.length() > 0) {parmMap.put(pi.name, valueStr); 
+                }
+
+
                 // check for missing required parameters
                 boolean parmMissing = false
                 for (ScreenDefinition.ParameterItem pi in sui.pathParameterItems.values()) {
@@ -1594,6 +1602,8 @@ class ScreenRenderImpl implements ScreenRender {
                 if (parmMissing) continue
                 String parmString = screenUrlInstance.getParameterString()
                 if (!parmString.isEmpty()) pathWithParams += ('?' + parmString)
+
+
 
                 String image = sui.menuImage
                 String imageType = sui.menuImageType

--- a/framework/xsd/xml-screen-2.1.xsd
+++ b/framework/xsd/xml-screen-2.1.xsd
@@ -479,6 +479,7 @@ along with this software (see the LICENSE.md file). If not, see
             highlighted.
         </xs:documentation></xs:annotation>
         <xs:complexType>
+            <xs:sequence><xs:element minOccurs="0" maxOccurs="unbounded" ref="parameter"/></xs:sequence>
             <xs:attribute name="name" type="name-plain" use="required">
                 <xs:annotation><xs:documentation>
                     The name of the subscreens item for use in the screen path. The screen path element following the


### PR DESCRIPTION
This pull request contains changes to support #259.  It would, for example, allow HiveMind's Project/EditUsers.xml to be moved to SimpleScreens WorkEffort/EditUsers.xml to be reused for other WorkEffort screens such as ProductionRuns and allow the roleGroupEnumId to be specified as a parameter for differentiating the role list between Projects and ProductionRuns.

Unlike the previous implementation, the roleGroupEnumId will be exposed to users as a GET parameter so the value could easily be changed to an incompatible value (such as a ProductionRun role group instead of Project for HiveMind Project screen).  If this is a concern then it the value would have to be validated before being stored.  This along with screens like this rarely ever being reusable are the only two reasons I can come up with for why this capability may be unnecessary.

If this change is deemed unnecessary then I'll just change the roleGroupEnumId value in a copy of EditUsers.xml for Production Runs.