### PR TITLE
EntityDataDocument.getDataDocuments() convert `data-time` field of en…

### DIFF
--- a/framework/src/main/groovy/org/moqui/impl/entity/EntityDataDocument.groovy
+++ b/framework/src/main/groovy/org/moqui/impl/entity/EntityDataDocument.groovy
@@ -249,7 +249,9 @@ class EntityDataDocument {
                 for (String pkFieldName in ddi.primaryPkFieldNames) {
                     if (!ddi.fieldAliasPathMap.containsKey(pkFieldName)) continue
                     if (pkCombinedSb.length() > 0) pkCombinedSb.append("::")
-                    pkCombinedSb.append((String) ev.getNoCheckSimple(pkFieldName))
+                    Object pkFieldValue = ev.getNoCheckSimple(pkFieldName)
+                    if (pkFieldValue instanceof Timestamp) pkFieldValue = ((Timestamp) pkFieldValue)?.getTime()
+                    pkCombinedSb.append((String) pkFieldValue)
                 }
                 String docId = pkCombinedSb.toString()
 
@@ -285,6 +287,7 @@ class EntityDataDocument {
                             for (int i = 0; i < fieldAliasList.size(); i++) {
                                 String fieldAlias = (String) fieldAliasList.get(i)
                                 Object curVal = ev.get(fieldAlias)
+                                if (curVal instanceof Timestamp) curVal = ((Timestamp) curVal)?.getTime()
                                 if (curVal != null) primaryEntityMap.put(fieldAlias, curVal)
                             }
                         }
@@ -514,6 +517,7 @@ class EntityDataDocument {
                     for (int i = 0; i < fieldAliasList.size(); i++) {
                         String fieldAlias = (String) fieldAliasList.get(i)
                         Object curVal = ev.get(fieldAlias)
+                        if (curVal instanceof Timestamp) curVal = ((Timestamp) curVal)?.getTime()
                         if (curVal != null) parentDocMap.put(fieldAlias, curVal)
                     }
                 }


### PR DESCRIPTION
…tity value (java type is Timestamp) to  java type `long`, so that it should avoid time zone issue when indexed by elasticsearch. Should resove issue https://github.com/moqui/moqui-elasticsearch/issues/3.

The underlying logic is: for a field with type `data-time` with value `1507600800000` which is time `2017-10-10T10:00:00+08:00 ` and `2017-10-10T02:00:00+00:00`, when elasticsearch index value with `Timestamp`, it gets string of the timestamp which is `2017-10-10 10:00:00`, since it is string, it will be indexed as UTC time which will become `2017-10-10 10:00:00+00:00 ` (= `2017-10-10T18:00:00+08:00 `).

By converting it to long value, it will be indexed by elasticsearch with format `epoch_millis`, therefore avoid the timezone issue.