### PR TITLE
Changed "original" field in moqui.basic.LocalizedMessage to "text-long"

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -82,7 +82,7 @@ Written in 2015 by Jimmy Shen - shendepu
 Written in 2015-2016 by Sam Hamilton - samhamilton
 Written in 2015 by Leonardo Carvalho - CarvalhoLeonardo
 Written in 2015 by Anton Akhiar - akhiar
-Writter in 2015-2016 by Jens Hardings - jenshp
+Written in 2015-2017 by Jens Hardings - jenshp
 Writter in 2016 by Shifeng Zhang - zhangshifeng
 Wrttien in 2016 by Scott Gray - lektran
 Written in 2016 by Mark Haney - mphaney

--- a/framework/entity/BasicEntities.xml
+++ b/framework/entity/BasicEntities.xml
@@ -215,7 +215,7 @@ along with this software (see the LICENSE.md file). If not, see
 
     <!-- ========== Localized ========== -->
     <entity entity-name="LocalizedMessage" package="moqui.basic" use="configuration" authorize-skip="view" cache="true">
-        <field name="original" type="text-medium" is-pk="true"/>
+        <field name="original" type="text-long" is-pk="true"/>
         <field name="locale" type="text-short" is-pk="true"/>
         <field name="localized" type="text-long"/>
     </entity>


### PR DESCRIPTION
Some messages exceed 255 characters, such as approve warnings in mantle.order.OrderInfoServices.check#OrderApprove and do not fit into a text-medium field.
The "localized" fields both in LocalizedMessage and LocalizedEntityField also are of type text-long.