### PR TITLE
Fix cache test when using a different locale

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -82,7 +82,7 @@ Written in 2015 by Jimmy Shen - shendepu
 Written in 2015-2016 by Sam Hamilton - samhamilton
 Written in 2015 by Leonardo Carvalho - CarvalhoLeonardo
 Written in 2015 by Anton Akhiar - akhiar
-Writter in 2015-2016 by Jens Hardings - jenshp
+Written in 2015-2017 by Jens Hardings - jenshp
 Writter in 2016 by Shifeng Zhang - zhangshifeng
 Wrttien in 2016 by Scott Gray - lektran
 Written in 2016 by Mark Haney - mphaney

--- a/framework/entity/BasicEntities.xml
+++ b/framework/entity/BasicEntities.xml
@@ -215,7 +215,7 @@ along with this software (see the LICENSE.md file). If not, see
 
     <!-- ========== Localized ========== -->
     <entity entity-name="LocalizedMessage" package="moqui.basic" use="configuration" authorize-skip="view" cache="true">
-        <field name="original" type="text-medium" is-pk="true"/>
+        <field name="original" type="text-long" is-pk="true"/>
         <field name="locale" type="text-short" is-pk="true"/>
         <field name="localized" type="text-long"/>
     </entity>


### PR DESCRIPTION
When using a non-english locale, the "auto cache clear for view one after update of member" test in EntityFindTests.groovy fails as it compares the localized value to the fixed string "Country".

Steps to reproduce:
1. start with latest moqui-framework and moqui-runtime
2. add line `<default-property name="default_locale" value="es_CL"/>` to runtime/conf/MoquiDevConf.xml
3. run 'gradle load test'

Observed behavior:
Fails test "auto cache clear for view one after update of member":
```
Condition not satisfied:

before.typeDescription == "Country"
|      |               |
|      País            false
|                      7 differences (0% similarity)
|                      (País---)
|                      (Country)
[typeEnumId:GEOT_COUNTRY, geoCodeAlpha2:US, typeEnumTypeId:GeoType, typeOptionValue:null, geoName:United States, geoCodeAlpha3:USA, geoId:USA, geoNameLocal:null, geoCodeNumeric:840, typeEnumCode:null, typeDescription:País, geoTypeEnumId:GEOT_COUNTRY, typeParentEnumId:null, wellKnownText:null, typeSequenceNum:null, typeRelatedEnumId:null]

	at EntityFindTests.auto cache clear for view one after update of member(EntityFindTests.groovy:248)

```

Expected results:
Tests should pass even if current locale is not english.

The fix sets the locale to en_US at the beginning of the test and sets it back to the original in the cleanup (after the conditions have been evaluated).