### PR TITLE
Fix cache test when using a different locale

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -82,7 +82,7 @@ Written in 2015 by Jimmy Shen - shendepu
 Written in 2015-2016 by Sam Hamilton - samhamilton
 Written in 2015 by Leonardo Carvalho - CarvalhoLeonardo
 Written in 2015 by Anton Akhiar - akhiar
-Writter in 2015-2016 by Jens Hardings - jenshp
+Written in 2015-2017 by Jens Hardings - jenshp
 Writter in 2016 by Shifeng Zhang - zhangshifeng
 Wrttien in 2016 by Scott Gray - lektran
 Written in 2016 by Mark Haney - mphaney

--- a/framework/src/test/groovy/EntityFindTests.groovy
+++ b/framework/src/test/groovy/EntityFindTests.groovy
@@ -228,6 +228,9 @@ class EntityFindTests extends Specification {
 
     def "auto cache clear for view one after update of member"() {
         when:
+        // fix locale to en_US
+        Locale startLocale = ec.user.getLocale()
+        ec.user.setLocale(new Locale("en", "US"))
         EntityValue before = ec.entity.find("moqui.basic.GeoAndType").condition("geoId", "USA").useCache(true).one()
         ec.entity.makeValue("moqui.basic.Enumeration").setAll([enumId:"GEOT_COUNTRY", description:"Country2"]).update()
         EntityValue after = ec.entity.find("moqui.basic.GeoAndType").condition("geoId", "USA").useCache(true).one()
@@ -240,6 +243,10 @@ class EntityFindTests extends Specification {
         before.typeDescription == "Country"
         after.typeDescription == "Country2"
         reset.typeDescription == "Country"
+
+        cleanup:
+        // set back locale
+        ec.user.setLocale(startLocale)
     }
 
     def "auto cache clear for count by is not null after update"() {


### PR DESCRIPTION
When using a non-english locale, the "auto cache clear for view one after update of member" test in EntityFindTests.groovy fails as it compares the localized value to the fixed string "Country".

Steps to reproduce:
1. start with latest moqui-framework and moqui-runtime
2. add line `<default-property name="default_locale" value="es_CL"/>` to runtime/conf/MoquiDevConf.xml
3. run 'gradle load test'

Observed behavior:
Fails test "auto cache clear for view one after update of member":
```
Condition not satisfied:

before.typeDescription == "Country"
|      |               |
|      País            false
|                      7 differences (0% similarity)
|                      (País---)
|                      (Country)
[typeEnumId:GEOT_COUNTRY, geoCodeAlpha2:US, typeEnumTypeId:GeoType, typeOptionValue:null, geoName:United States, geoCodeAlpha3:USA, geoId:USA, geoNameLocal:null, geoCodeNumeric:840, typeEnumCode:null, typeDescription:País, geoTypeEnumId:GEOT_COUNTRY, typeParentEnumId:null, wellKnownText:null, typeSequenceNum:null, typeRelatedEnumId:null]

	at EntityFindTests.auto cache clear for view one after update of member(EntityFindTests.groovy:248)

```

Expected results:
Tests should pass even if current locale is not english.

The fix sets the locale to en_US at the beginning of the test and sets it back to the original in the cleanup (after the conditions have been evaluated).