### PR TITLE
Unit tests for sub-select

### DIFF
--- a/framework/entity/TestEntities.xml
+++ b/framework/entity/TestEntities.xml
@@ -32,6 +32,26 @@ along with this software (see the LICENSE.md file). If not, see
         <field name="testCurrencyAmount" type="currency-amount"/>
         <field name="testCurrencyPrecise" type="currency-precise"/>
     </entity>
+    <entity entity-name="Foo" package="moqui.test" sequence-bank-size="100">
+        <field name="fooId" type="id" is-pk="true"/>
+        <field name="fooText" type="text-medium"/>
+    </entity>
+    <entity entity-name="Bar" package="moqui.test" sequence-bank-size="100">
+        <field name="barId" type="id" is-pk="true" />
+        <field name="fooId" type="id"></field>
+        <field name="rank" type="number-integer"></field>
+        <field name="score" type="number-decimal"></field>
+    </entity>
+    <view-entity entity-name="FooBar" package="moqui.test">
+        <member-entity entity-alias="T1" entity-name="moqui.test.Foo" />
+        <member-entity entity-alias="T2" entity-name="moqui.test.Bar" sub-select="true"
+                       join-optional="true" join-from-alias="T1">
+            <key-map field-name="fooId" />
+        </member-entity>
+        <alias-all entity-alias="T1" />
+        <alias name="score" function="sum" entity-alias="T2" />
+        <alias name="rank" entity-alias="T2" />
+    </view-entity>
     <entity entity-name="TestNoSqlEntity" package="moqui.test" sequence-bank-size="100" use="nontransactional" cache="never">
         <field name="testId" type="id" is-pk="true"/>
         <field name="testMedium" type="text-medium"/>

--- a/framework/src/main/groovy/org/moqui/impl/entity/condition/ConditionField.java
+++ b/framework/src/main/groovy/org/moqui/impl/entity/condition/ConditionField.java
@@ -41,11 +41,11 @@ public class ConditionField implements Externalizable {
 
     public String getFieldName() { return fieldName; }
     public String getColumnName(EntityDefinition ed) {
-        if (fieldInfo != null) return fieldInfo.getFullColumnName();
+        if (fieldInfo != null && fieldInfo.ed.equals(ed)) return fieldInfo.getFullColumnName();
         return ed.getColumnName(fieldName);
     }
     public FieldInfo getFieldInfo(EntityDefinition ed) {
-        if (fieldInfo != null) return fieldInfo;
+        if (fieldInfo != null && fieldInfo.ed.equals(ed)) return fieldInfo;
         return ed.getFieldInfo(fieldName);
     }
 

--- a/framework/src/test/groovy/MoquiSuite.groovy
+++ b/framework/src/test/groovy/MoquiSuite.groovy
@@ -21,7 +21,7 @@ import org.moqui.Moqui
 @RunWith(Suite.class)
 @Suite.SuiteClasses([ CacheFacadeTests.class, EntityCrud.class, EntityFindTests.class, EntityNoSqlCrud.class,
         L10nFacadeTests.class, MessageFacadeTests.class, ResourceFacadeTests.class,
-        ServiceCrudImplicit.class, ServiceFacadeTests.class, TransactionFacadeTests.class, UserFacadeTests.class,
+        ServiceCrudImplicit.class, ServiceFacadeTests.class, SubSelectTests.class, TransactionFacadeTests.class, UserFacadeTests.class,
         SystemScreenRenderTests.class, ToolsRestApiTests.class, ToolsScreenRenderTests.class])
 class MoquiSuite {
     @AfterClass

--- a/framework/src/test/groovy/SubSelectTests.groovy
+++ b/framework/src/test/groovy/SubSelectTests.groovy
@@ -49,6 +49,11 @@ class SubSelectTests extends Specification {
     def setup() {
         ec.artifactExecution.disableAuthz()
         ec.transaction.begin(null)
+        // create some entity to trigger the table creation.
+        ec.entity.makeValue("moqui.test.Foo").setAll([fooId:"EXTST1"]).createOrUpdate()
+        ec.entity.makeValue("moqui.test.Bar").setAll([barId:"EXTST1"]).createOrUpdate()
+        ec.entity.makeValue("moqui.test.Foo").setAll([fooId:"EXTST1"]).delete()
+        ec.entity.makeValue("moqui.test.Bar").setAll([barId:"EXTST1"]).delete()
     }
 
     def cleanup() {
@@ -60,8 +65,9 @@ class SubSelectTests extends Specification {
         when:
         EntityFind find =  ec.entity.find("moqui.test.FooBar").searchFormMap(["rank":100], null,null,null,true)
         EntityList list = find.list()
-        then:
 
+        then:
+        list.isEmpty()
         find.getQueryTextList()[0].contains(" RANK = ? ")
     }
 
@@ -69,7 +75,9 @@ class SubSelectTests extends Specification {
         when:
         EntityFind find = ec.entity.find("moqui.test.FooBar").searchFormMap(["rank_from":100], null,null,null,true)
         EntityList list = find.list()
+
         then:
+        list.isEmpty()
         find.getQueryTextList()[0].contains(" RANK >= ? ")
     }
 }

--- a/framework/src/test/groovy/SubSelectTests.groovy
+++ b/framework/src/test/groovy/SubSelectTests.groovy
@@ -1,0 +1,75 @@
+/*
+ * This software is in the public domain under CC0 1.0 Universal plus a
+ * Grant of Patent License.
+ * 
+ * To the extent possible under law, the author(s) have dedicated all
+ * copyright and related and neighboring rights to this software to the
+ * public domain worldwide. This software is distributed without any
+ * warranty.
+ * 
+ * You should have received a copy of the CC0 Public Domain Dedication
+ * along with this software (see the LICENSE.md file). If not, see
+ * <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+
+
+import org.moqui.Moqui
+import org.moqui.context.ExecutionContext
+import org.moqui.entity.EntityCondition
+import org.moqui.entity.EntityFind
+import org.moqui.entity.EntityList
+import org.moqui.entity.EntityValue
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+import spock.lang.Ignore
+import spock.lang.Shared
+import spock.lang.Specification
+import spock.lang.Unroll
+
+import java.sql.Timestamp
+
+class SubSelectTests extends Specification {
+    protected final static Logger logger = LoggerFactory.getLogger(SubSelectTests.class)
+
+    @Shared
+    ExecutionContext ec
+    @Shared
+    Timestamp timestamp
+
+    def setupSpec() {
+        // init the framework, get the ec
+        ec = Moqui.getExecutionContext()
+        timestamp = ec.user.nowTimestamp
+    }
+
+    def cleanupSpec() {
+        ec.destroy()
+    }
+
+    def setup() {
+        ec.artifactExecution.disableAuthz()
+        ec.transaction.begin(null)
+    }
+
+    def cleanup() {
+        ec.artifactExecution.enableAuthz()
+        ec.transaction.commit()
+    }
+
+    def "find subselect search form equal"() {
+        when:
+        EntityFind find =  ec.entity.find("moqui.test.FooBar").searchFormMap(["rank":100], null,null,null,true)
+        EntityList list = find.list()
+        then:
+
+        find.getQueryTextList()[0].contains(" RANK = ? ")
+    }
+
+    def "find subselect search form range"() {
+        when:
+        EntityFind find = ec.entity.find("moqui.test.FooBar").searchFormMap(["rank_from":100], null,null,null,true)
+        EntityList list = find.list()
+        then:
+        find.getQueryTextList()[0].contains(" RANK >= ? ")
+    }
+}


### PR DESCRIPTION
This is an simple unit tests for sub-select.
Sometime generated WHERE clause for sub query use `entity-alians.field-name`,  It should be `field-name` only.
The unit test contains two case, one will fail, another will pass.