### PR TITLE
Handled case where jndi-jdbc is defined without a inline-jdbc node.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -88,3 +88,4 @@ Wrttien in 2016 by Scott Gray - lektran
 Written in 2016 by Mark Haney - mphaney
 Writter in 2016 by Qiushi Yan - yanqiushi
 Written in 2017 by Oleg Andrieiev - oandreyev
+Written in 2018 by Ayman Abi Abdallah - aabiabdallah

--- a/framework/src/main/groovy/org/moqui/impl/entity/EntityFacadeImpl.groovy
+++ b/framework/src/main/groovy/org/moqui/impl/entity/EntityFacadeImpl.groovy
@@ -234,7 +234,7 @@ class EntityFacadeImpl implements EntityFacade {
                 MNode dbNode = efi.getDatabaseNode(groupName)
                 inlineJdbc = dbNode.first("inline-jdbc")
             }
-            MNode xaProperties = inlineJdbc.first("xa-properties")
+            MNode xaProperties = inlineJdbc==null ? null : inlineJdbc.first("xa-properties")
             database = efi.getDatabaseNode(groupName)
 
             if (jndiJdbcNode != null) {


### PR DESCRIPTION
The system is throwing a NPE when a jndi-jdbc node is defined without a inline-jdbc node.