### PR TITLE
Add new gradle task 'createComponent'

### DIFF
--- a/addons.xml
+++ b/addons.xml
@@ -25,6 +25,7 @@
 
     <!-- Example Component -->
     <component name="example" group="moqui" version="2.1.0" branch="master"/>
+    <component name="moqui-component-template" group="telenieko" branch="master" />
 
     <!-- Moqui Tool Components -->
     <component name="moqui-atomikos" group="moqui" version="1.0.0" branch="master"/>

--- a/build.gradle
+++ b/build.gradle
@@ -538,13 +538,22 @@ task createComponent(description: 'create a new component based on the moqui exa
         compXmlFile.withWriter { w->
             w.write( XmlUtil.serialize(compXml))
         }
-
         // cleanup the example
-        file("${componentDir.path}/LICENSE.md").delete()
-        file("${componentDir.path}/AUTHORS").delete()
-        if(file("${componentDir.path}/.git").exists())
-            file("${componentDir.path}/.git").deleteDir()
-
+        File removeFilesFile = file("${componentDir.path}/remove-files.txt")
+        if(removeFilesFile.exists()) {
+            removeFilesFile.withReader { r ->
+                String fpath = ""
+                while ((fpath = r.readLine())!=null) {
+                    File f = file("${componentDir.path}/${fpath}")
+                    if(!f.exists())
+                        continue
+                    if(f.isFile())
+                        f.delete()
+                    if(f.isDirectory())
+                        f.deleteDir()
+                }
+            }
+        }
         logger.lifecycle("Created new component ${componentName}, dependent components checked: ${compsChecked}")
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -516,9 +516,6 @@ task createComponent(description: 'create a new component based on the moqui exa
         if (!project.hasProperty('component')) {
             throw new InvalidUserDataException("No component property specified")
         }
-        if (!project.hasProperty('baseComponent')) {
-            baseComponent = "example"
-        }
         String componentName = component
         String curLocationType = file('.git').exists() ? 'git' : 'current'
         if (project.hasProperty('locationType')) curLocationType = locationType

--- a/build.gradle
+++ b/build.gradle
@@ -18,6 +18,7 @@ buildscript {
 }
 // Not needed for explicit use, causes problems when not from git repo: plugins { id 'org.ajoberstar.grgit' version 'x.y.z' }
 
+import groovy.xml.XmlUtil
 import org.ajoberstar.grgit.*
 
 defaultTasks 'build'
@@ -508,6 +509,48 @@ def checkAllComponentDependencies(String type) {
     logger.lifecycle("Dependent components checked: ${compsChecked}")
 }
 
+task createComponent(description: 'create a new component based on the moqui example') {
+    doLast {
+        String baseComponent = project.hasProperty('baseComponent') ? project['baseComponent'] : "moqui-component-template"
+
+        if (!project.hasProperty('component')) {
+            throw new InvalidUserDataException("No component property specified")
+        }
+        if (!project.hasProperty('baseComponent')) {
+            baseComponent = "example"
+        }
+        String componentName = component
+        String curLocationType = file('.git').exists() ? 'git' : 'current'
+        if (project.hasProperty('locationType')) curLocationType = locationType
+
+        Set compsChecked = new TreeSet()
+        Node addons = parseAddons()
+        Node myaddons = parseMyaddons()
+
+        Node component = myaddons != null ? (Node) myaddons.component.find({ it."@name" == baseComponent }) : null
+        if (component == null) component = (Node) addons.component.find({ it."@name" == baseComponent })
+        if (component == null) throw new InvalidUserDataException("Could not find the ${baseComponent} component in myaddons.xml or addons.xml")
+
+        File componentDir = downloadComponent("runtime/component/${componentName}", curLocationType, component, addons, myaddons)
+        checkComponentDependencies(componentName, curLocationType, addons, myaddons, compsChecked)
+
+        // set component name in component.xml
+        File compXmlFile = file("${componentDir.path}/component.xml")
+        Node compXml = new XmlParser().parse(compXmlFile)
+        compXml["@name"] = componentName
+        compXmlFile.withWriter { w->
+            w.write( XmlUtil.serialize(compXml))
+        }
+
+        // cleanup the example
+        file("${componentDir.path}/LICENSE.md").delete()
+        file("${componentDir.path}/AUTHORS").delete()
+        if(file("${componentDir.path}/.git").exists())
+            file("${componentDir.path}/.git").deleteDir()
+
+        logger.lifecycle("Created new component ${componentName}, dependent components checked: ${compsChecked}")
+    }
+}
 // ========== combined tasks ==========
 
 task cleanPullLoad { dependsOn cleanAll, gitPullAll, load }


### PR DESCRIPTION
This task allows to easily create new components like the createPlugin
task from OFBiz.

Usage:
  ./gradlew createComponent -Pcomponent=mycomponent

You can also supply your own template (must exist in myaddons.xml or addons.xml):
  ./gradlew createComponent -Pcomponent=mycomponent -PbaseComponent=moqui-component-template

NOTE: This commit adds a component to addons.xml which is a base template based on the moqui example.
If this goes into Moqui, that template or anotherone shall be put in its place.