### PR TITLE
Improved the message content shown when user request for password reset

### DIFF
--- a/framework/screen/PasswordReset.xml
+++ b/framework/screen/PasswordReset.xml
@@ -16,7 +16,7 @@ along with this software (see the LICENSE.md file). If not, see
     <widgets>
         <render-mode><text type="html"><![CDATA[<html><body>]]></text></render-mode>
         <container><label text="Your reset password has been set to: ${resetPassword}"/></container>
-        <container><label text="Please use this reset password to change your password immediately."/></container>
+        <container><label text="This password can't be used for login, please use this reset password to change your password immediately."/></container>
         <container><label text="Your current password is still valid, this reset password may only be used to change your password."/></container>
         <section name="RequireChangeSection" condition="userAccount.requirePasswordChange == 'Y'"><widgets>
             <container><label text="Your password must be changed before login."/></container>


### PR DESCRIPTION
Since, the reset password can't be used for login, added this information.