### PR TITLE
Curr rounding

### DIFF
--- a/framework/src/main/groovy/org/moqui/impl/context/L10nFacadeImpl.java
+++ b/framework/src/main/groovy/org/moqui/impl/context/L10nFacadeImpl.java
@@ -132,6 +132,18 @@ public class L10nFacadeImpl implements L10nFacade {
     }
 
     @Override
+    public BigDecimal roundCurrency(BigDecimal amount, String uomId) { return roundCurrency(amount, uomId, false); }
+    @Override
+    public BigDecimal roundCurrency(BigDecimal amount, String uomId, boolean precise) { return roundCurrency(amount, uomId, false, BigDecimal.ROUND_HALF_UP); }
+    @Override
+    public BigDecimal roundCurrency(BigDecimal amount, String uomId, boolean precise, int roundingMethod) {
+        Currency currency = Currency.getInstance(uomId);
+        int nDigits = currency.getDefaultFractionDigits();
+        if (precise) nDigits++;
+        return amount.setScale(nDigits, roundingMethod);
+    }
+
+    @Override
     public Time parseTime(String input, String format) {
         Locale curLocale = getLocale();
         TimeZone curTz = getTimeZone();

--- a/framework/src/main/java/org/moqui/context/L10nFacade.java
+++ b/framework/src/main/java/org/moqui/context/L10nFacade.java
@@ -44,6 +44,17 @@ public interface L10nFacade {
     String formatCurrency(Object amount, String uomId);
     String formatCurrency(Object amount, String uomId, Integer fractionDigits, Locale locale);
 
+    /** Round currency according to the currency's specified amount of digits and rounding method.
+     * @param amount The amount in BigDecimal to be rounded.
+     * @param uomId The currency uomId (ISO currency code), required
+     * @param precise A boolean indicating whether the currency should be treated with an additional digit
+     * @param roundingMethod Rounding method to use (e.g. BigDecimal.ROUND_HALF_UP)
+     * @return The rounded currency amount.
+     */
+    java.math.BigDecimal roundCurrency(java.math.BigDecimal amount, String uomId, boolean precise, int roundingMethod);
+    java.math.BigDecimal roundCurrency(java.math.BigDecimal amount, String uomId, boolean precise);
+    java.math.BigDecimal roundCurrency(java.math.BigDecimal amount, String uomId);
+
     /** Format a Number, Timestamp, Date, Time, or Calendar object using the given format string. If no format string
      * is specified the default for the user's locale and time zone will be used.
      *

--- a/framework/src/main/resources/MoquiDefaultConf.xml
+++ b/framework/src/main/resources/MoquiDefaultConf.xml
@@ -380,8 +380,8 @@
         <dictionary-type type="number-decimal" java-type="java.math.BigDecimal" default-sql-type="NUMERIC(26,6)"/>
         <dictionary-type type="number-float" java-type="java.lang.Double" default-sql-type="DOUBLE"/>
 
-        <dictionary-type type="currency-amount" java-type="java.math.BigDecimal" default-sql-type="NUMERIC(22,2)"/>
-        <dictionary-type type="currency-precise" java-type="java.math.BigDecimal" default-sql-type="NUMERIC(23,3)"/>
+        <dictionary-type type="currency-amount" java-type="java.math.BigDecimal" default-sql-type="NUMERIC(24,4)"/>
+        <dictionary-type type="currency-precise" java-type="java.math.BigDecimal" default-sql-type="NUMERIC(25,5)"/>
 
         <dictionary-type type="text-indicator" java-type="java.lang.String" default-sql-type="CHAR(1)"/>
         <dictionary-type type="text-short" java-type="java.lang.String" default-sql-type="VARCHAR(63)"/>
@@ -419,8 +419,8 @@
             <database-type type="number-integer" sql-type="DECIMAL(20,0)"/>
             <database-type type="number-decimal" sql-type="DECIMAL(26,6)"/>
             <database-type type="number-float" sql-type="DECIMAL(30,12)"/>
-            <database-type type="currency-amount" sql-type="DECIMAL(22,2)"/>
-            <database-type type="currency-precise" sql-type="DECIMAL(23,3)"/>
+            <database-type type="currency-amount" sql-type="DECIMAL(24,4)"/>
+            <database-type type="currency-precise" sql-type="DECIMAL(25,5)"/>
 
             <inline-jdbc><xa-properties driverType="4" serverName="${entity_ds_host}" portNumber="${entity_ds_port?:'50000'}"
                     databaseName="${entity_ds_database}" user="${entity_ds_user}" password="${entity_ds_password}"/></inline-jdbc>
@@ -435,8 +435,8 @@
             <database-type type="number-integer" sql-type="DECIMAL(20,0)"/>
             <database-type type="number-decimal" sql-type="DECIMAL(26,6)"/>
             <database-type type="number-float" sql-type="DECIMAL(30,12)"/>
-            <database-type type="currency-amount" sql-type="DECIMAL(22,2)"/>
-            <database-type type="currency-precise" sql-type="DECIMAL(23,3)"/>
+            <database-type type="currency-amount" sql-type="DECIMAL(24,4)"/>
+            <database-type type="currency-precise" sql-type="DECIMAL(25,5)"/>
 
             <inline-jdbc><xa-properties serverName="${entity_ds_host}" databaseName="${entity_ds_database}"
                     user="${entity_ds_user}" password="${entity_ds_password}" cursorHold="false" threadUsed="false"/></inline-jdbc>
@@ -522,8 +522,8 @@
             <database-type type="number-decimal" sql-type="DECIMAL(26,6)"/>
             <database-type type="number-float" sql-type="DECIMAL(32,12)"/>
 
-            <database-type type="currency-amount" sql-type="DECIMAL(22,2)"/>
-            <database-type type="currency-precise" sql-type="DECIMAL(23,3)"/>
+            <database-type type="currency-amount" sql-type="DECIMAL(24,4)"/>
+            <database-type type="currency-precise" sql-type="DECIMAL(25,5)"/>
 
             <database-type type="text-indicator" sql-type="CHAR(1)"/>
             <database-type type="text-short" sql-type="NVARCHAR(63)"/>
@@ -569,8 +569,8 @@
             <database-type type="number-decimal" sql-type="DECIMAL(26,6)"/>
             <database-type type="number-float" sql-type="DECIMAL(32,12)"/>
 
-            <database-type type="currency-amount" sql-type="DECIMAL(22,2)"/>
-            <database-type type="currency-precise" sql-type="DECIMAL(23,3)"/>
+            <database-type type="currency-amount" sql-type="DECIMAL(24,4)"/>
+            <database-type type="currency-precise" sql-type="DECIMAL(25,5)"/>
 
             <database-type type="text-very-long" sql-type="LONGTEXT"/>
             <database-type type="binary-very-long" sql-type="LONGBLOB"/>
@@ -592,8 +592,8 @@
             <database-type type="number-decimal" sql-type="DECIMAL(26,6)"/>
             <database-type type="number-float" sql-type="DECIMAL(32,12)"/>
 
-            <database-type type="currency-amount" sql-type="DECIMAL(22,2)"/>
-            <database-type type="currency-precise" sql-type="DECIMAL(23,3)"/>
+            <database-type type="currency-amount" sql-type="DECIMAL(24,4)"/>
+            <database-type type="currency-precise" sql-type="DECIMAL(25,5)"/>
 
             <database-type type="text-very-long" sql-type="LONGTEXT"/>
             <database-type type="binary-very-long" sql-type="LONGBLOB"/>
@@ -624,8 +624,8 @@
             <database-type type="number-decimal" sql-type="NUMBER(26,6)"/>
             <database-type type="number-float" sql-type="NUMBER(32,12)"/>
 
-            <database-type type="currency-amount" sql-type="NUMBER(22,2)"/>
-            <database-type type="currency-precise" sql-type="NUMBER(23,3)"/>
+            <database-type type="currency-amount" sql-type="NUMBER(24,4)"/>
+            <database-type type="currency-precise" sql-type="NUMBER(25,5)"/>
 
             <database-type type="text-short" sql-type="VARCHAR2(10)"/>
             <database-type type="text-medium" sql-type="VARCHAR2(255)"/>


### PR DESCRIPTION
Increase precision of the decimal value for storing currency values to 4 for normal and 5 for currency-precise.

Add methods to round currency values according to the currencyUomId.