### PR TITLE
Add basic health check to docker image

### DIFF
--- a/docker/simple/Dockerfile
+++ b/docker/simple/Dockerfile
@@ -34,5 +34,7 @@ EXPOSE 5701
 # this is to run from the war file directly, preferred approach unzips war file in advance
 # ENTRYPOINT ["java", "-jar", "moqui.war"]
 ENTRYPOINT ["java", "-cp", ".", "MoquiStart", "port=80"]
+
+HEALTHCHECK --interval=30s --timeout=600ms --start-period=120s CMD curl -f -H "X-Forwarded-Proto: https" -H "X-Forwarded-Ssl: on" http://localhost/status || exit 1
 # specify this as a default parameter if none are specified with docker exec/run, ie run production by default
 CMD ["conf=conf/MoquiProductionConf.xml"]

--- a/framework/src/main/resources/MoquiDefaultConf.xml
+++ b/framework/src/main/resources/MoquiDefaultConf.xml
@@ -32,6 +32,7 @@
     <default-property name="entity_ds_crypt_pass" value="MoquiDefaultPassword:CHANGEME"/>
     <default-property name="entity_add_missing_runtime" value=""/>
     <default-property name="entity_add_missing_startup" value=""/>
+    <default-property name="instance_docker_host_ips" value="127.0.0.1"/>
 
     <tools empty-db-load="seed,seed-initial,install" worker-queue="65535" worker-pool-core="16" worker-pool-max="24" worker-pool-alive="60">
         <tool-factory class="org.moqui.impl.tools.MCacheToolFactory" init-priority="03" disabled="false"/>

--- a/framework/src/main/resources/MoquiDefaultConf.xml
+++ b/framework/src/main/resources/MoquiDefaultConf.xml
@@ -32,7 +32,7 @@
     <default-property name="entity_ds_crypt_pass" value="MoquiDefaultPassword:CHANGEME"/>
     <default-property name="entity_add_missing_runtime" value=""/>
     <default-property name="entity_add_missing_startup" value=""/>
-    <default-property name="instance_docker_host_ips" value="127.0.0.1"/>
+    <default-property name="webapp_status_ips" value="127.0.0.1"/>
 
     <tools empty-db-load="seed,seed-initial,install" worker-queue="65535" worker-pool-core="16" worker-pool-max="24" worker-pool-alive="60">
         <tool-factory class="org.moqui.impl.tools.MCacheToolFactory" init-priority="03" disabled="false"/>


### PR DESCRIPTION
Enables very basic health check, accessing /status transition.
Requires pull request https://github.com/moqui/moqui-runtime/pull/143 which enables /status for requests coming from localhost.