### PR TITLE
Made the taga/tagb parameters required and allowed 'HEAD' to be used

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -282,8 +282,9 @@ task gitDiffTagsAll {
     doLast {
         if (!project.hasProperty('taga') || taga == null) 
             throw new InvalidUserDataException("No taga property specified (use -Ptaga=...)")
-        if (!project.hasProperty('tagb') || tagb == null) 
-            throw new InvalidUserDataException("No tagb property specified (use -Ptagb=...)")
+
+        // If tagb is not passed, we assume HEAD
+        def tagb = (project.hasProperty('tagb') && tagb != null) ? tagb : "HEAD";
 
         logger.lifecycle("== Git diffing tags ${taga} and ${tagb}")
 

--- a/build.gradle
+++ b/build.gradle
@@ -257,7 +257,6 @@ task gitTagAll {
                         curGrgit.tag.add(name: tagName, message: tagMessage ?: "Tagging version ${tagName}")
                         logger.lifecycle("== Git tagging commit ${commit.abbreviatedId} - '${commit.shortMessage}' by '${commit.author.name}' in ${branchName} of ${relativePath}")
                     }
-
                 } else {
                     if (removeTags) {
                         curGrgit.tag.remove(names: [tagName])
@@ -275,17 +274,16 @@ task gitTagAll {
                 }
                 logger.lifecycle("== Git pushing tag changes to remote of ${relativePath}")
             }
-
         }
     }
 }
 task gitDiffTagsAll {
-    description "Do a git add or remove tag on the currently checked out commit in moqui, runtime, and each installed component"
+    description "Do a git diff between two tags in the currently checked out branch in moqui, runtime, and each installed component"
     doLast {
         def tagAName = (project.hasProperty('taga')) ? taga : null;
         def tagBName = (project.hasProperty('tagb')) ? tagb : null;
 
-        logger.lifecycle("Diffing tags ${tagAName} and ${tagBName}")
+        logger.lifecycle("== Git diffing tags ${tagAName} and ${tagBName}")
 
         List<String> gitDirectories = []
         if (file(".git").exists()) gitDirectories.add(file('.').path)
@@ -306,7 +304,7 @@ task gitDiffTagsAll {
 
             if (targetTagA != null && targetTagB != null) {
                 grgit.log {
-                  range tagAName, tagBName
+                    range tagAName, tagBName
                 }.each {
                     logger.lifecycle("    ${it.abbreviatedId} - ${it.shortMessage}")
                 }

--- a/build.gradle
+++ b/build.gradle
@@ -280,10 +280,12 @@ task gitTagAll {
 task gitDiffTagsAll {
     description "Do a git diff between two tags in the currently checked out branch in moqui, runtime, and each installed component"
     doLast {
-        def tagAName = (project.hasProperty('taga')) ? taga : null;
-        def tagBName = (project.hasProperty('tagb')) ? tagb : null;
+        if (!project.hasProperty('taga') || taga == null) 
+            throw new InvalidUserDataException("No taga property specified (use -Ptaga=...)")
+        if (!project.hasProperty('tagb') || tagb == null) 
+            throw new InvalidUserDataException("No tagb property specified (use -Ptagb=...)")
 
-        logger.lifecycle("== Git diffing tags ${tagAName} and ${tagBName}")
+        logger.lifecycle("== Git diffing tags ${taga} and ${tagb}")
 
         List<String> gitDirectories = []
         if (file(".git").exists()) gitDirectories.add(file('.').path)
@@ -297,14 +299,14 @@ task gitDiffTagsAll {
             def grgit = Grgit.open(dir: gitDir)
 
             def tagList = grgit.tag.list()
-            def targetTagA = tagList.find({ it.name == tagAName })
-            def targetTagB = tagList.find({ it.name == tagBName })
+            def tagaCommit = tagList.find({ it.name == taga })
+            def tagbCommit = tagList.find({ it.name == tagb })
 
             logger.lifecycle("${relativePath}")
 
-            if (targetTagA != null && targetTagB != null) {
-                grgit.log {
-                    range tagAName, tagBName
+            if ((taga == "HEAD" || tagaCommit != null) && (tagb == "HEAD" || tagbCommit != null)) {
+                grgit.log { 
+                    range taga, tagb
                 }.each {
                     logger.lifecycle("    ${it.abbreviatedId} - ${it.shortMessage}")
                 }


### PR DESCRIPTION
users can now call:

`gradle gitDiffTagsAll -Ptaga=v1.0.0 -Ptagb=HEAD`

or

`gradle gitDiffTagsAll -Ptaga=v1.0.0`

In both cases, the diff will be between tag v1.0.0 and HEAD