### PR TITLE
Add enum for loading custom favicon

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -55,6 +55,8 @@ Written in 2018 by Zhang Wei - zhangwei1979
 Written in 2018 by Nirendra Singh - nirendra10695
 Written in 2018 by Ayman Abi Abdallah - aabiabdallah
 Written in 2019 by Daniel Taylor - danieltaylor-nz
+Written in 2019 by Arzang Kasiri - akasiri
+
 ===========================================================================
 
 Grant of Patent License
@@ -95,3 +97,4 @@ Written in 2018 by Zhang Wei - zhangwei1979
 Written in 2018 by Nirendra Singh - nirendra10695
 Written in 2018 by Ayman Abi Abdallah - aabiabdallah
 Written in 2019 by Daniel Taylor - danieltaylor-nz
+Written in 2019 by Arzang Kasiri - akasiri

--- a/framework/entity/ScreenEntities.xml
+++ b/framework/entity/ScreenEntities.xml
@@ -109,6 +109,7 @@ along with this software (see the LICENSE.md file). If not, see
             <moqui.basic.Enumeration description="Footer Item" enumId="STRT_FOOTER_ITEM" enumTypeId="ScreenThemeResourceType"/>
             <moqui.basic.Enumeration description="HTML Body CSS Class" enumId="STRT_BODY_CLASS" enumTypeId="ScreenThemeResourceType"/>
             <moqui.basic.Enumeration description="Theme Preview Screenshot" enumId="STRT_SCREENSHOT" enumTypeId="ScreenThemeResourceType"/>
+            <moqui.basic.Enumeration description="Shortcut Icon Resource Location" enumId="STRT_SHORTCUT_ICON_LOCATION" enumTypeId="ScreenThemeResourceType"/>
         </seed-data>
     </entity>
     <entity entity-name="ScreenThemeIcon" package="moqui.screen" use="configuration" cache="true">


### PR DESCRIPTION
Adding an enum necessary for a moqui-runtime feature I submitted a PR for: [moqui-runtime #147](https://github.com/moqui/moqui-runtime/pull/147).