### PR TITLE
Add gradle task to merge all repositories using tag or branch name

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -316,6 +316,52 @@ task gitDiffTagsAll {
     }
 }
 
+task gitMergeAll {
+    description "Do a git diff between two tags in the currently checked out branch in moqui, runtime, and each installed component"
+    doLast {
+        def branchName = (project.hasProperty('branch')) ? branch : null;
+        def tagName = (project.hasProperty('tag')) ? tag : null;
+        def pushMerge = (project.hasProperty('push')) ? push : null;
+
+
+        List<String> gitDirectories = []
+        if (file(".git").exists()) gitDirectories.add(file('.').path)
+        if (file("runtime/.git").exists()) gitDirectories.add(file('runtime').path)
+        for (File compDir in file('runtime/component').listFiles().findAll { it.isDirectory() && it.listFiles().find { it.name == '.git' } })
+            gitDirectories.add(compDir.path)
+
+        def frameworkDir = gitDirectories.first()
+        for (String gitDir in gitDirectories) {
+            def relativePath = "."+gitDir.minus(frameworkDir)
+            logger.lifecycle("${relativePath}")
+            def grgit = Grgit.open(dir: gitDir)
+            def currentBranch = grgit.branch.current()?.name;
+            if (branchName == currentBranch)
+                continue
+
+            def doMerge = false;
+
+            if (branchName && grgit.branch.list().find({ it.name == branchName }) != null) {
+                doMerge = true;
+            }
+
+            if (tagName && grgit.tag.list().find({ it.name == tagName }) != null) {
+                doMerge = true;
+            }
+
+            if (doMerge) {
+                grgit.merge(head: branchName ?: tagName)
+                logger.lifecycle("    Merging ${branchName ?: tagName} into ${currentBranch}")
+            }
+
+            if (pushMerge) {
+                grgit.push();
+                logger.lifecycle("    Pushing merge")
+            }
+        }
+    }
+}
+
 // ========== run tasks ==========
 
 task run(type: JavaExec) {

--- a/build.gradle
+++ b/build.gradle
@@ -321,6 +321,8 @@ task gitMergeAll {
     doLast {
         def branchName = (project.hasProperty('branch')) ? branch : null;
         def tagName = (project.hasProperty('tag')) ? tag : null;
+        def mergeMode = (project.hasProperty('mode')) ? mode : null;
+        def mergeMessage = (project.hasProperty('message')) ? message : null;
         def pushMerge = (project.hasProperty('push')) ? push : null;
 
 
@@ -350,7 +352,7 @@ task gitMergeAll {
             }
 
             if (doMerge) {
-                grgit.merge(head: branchName ?: tagName)
+                grgit.merge(head: branchName ?: tagName, mode: mergeMode, message: mergeMessage)
                 logger.lifecycle("    Merging ${branchName ?: tagName} into ${currentBranch}")
             }
 


### PR DESCRIPTION
Task to handle the merging of the framework and all components.

1. first checkout the source branch and do a gitPullAll
```
gradle gitCheckoutAll -Pbranch=master
gradle gitPullAll
```

2. Next checkout the target branch and ensure all components are updated also
```
gradle gitCheckoutAll -Pbranch=deployment
gradle gitPullAll
```

3. Last merge the source branch into target branch and push
`gradle gitMergeAll -Pbranch=master -Ppush=true`

Other use cases would be merging a tag:
`gradle gitMergeAll -Ptag=v101 -Ppush=true`

There are the optional parameters 'message', 'mode' and 'push'
- If no message is passed, the default merge message in git is used.
- The modes used by grgit are available here: https://ajoberstar.org/grgit/grgit-merge.html
- Pushing is optional, but there isn't a gradle gitPushAll task yet so it become a little manual if you don't.
