### PR TITLE
Corrected wrong condition in service ECA rule.

### DIFF
--- a/framework/src/main/groovy/org/moqui/impl/service/ServiceEcaRule.groovy
+++ b/framework/src/main/groovy/org/moqui/impl/service/ServiceEcaRule.groovy
@@ -72,7 +72,7 @@ class ServiceEcaRule {
     void runIfMatches(String serviceName, Map<String, Object> parameters, Map<String, Object> results, String when, ExecutionContextImpl ec) {
         // see if we match this event and should run
         if (!nameIsPattern && !serviceNameNoHash.equals(serviceName)) return
-        if (nameIsPattern && !serviceName.matches(this.serviceName)) return
+        if (nameIsPattern && !serviceName.matches(this.serviceNameNoHash)) return
         if (!this.when.equals(when)) return
         if (!runOnError && ec.getMessage().hasError()) return
 


### PR DESCRIPTION
The runIfMatches method is always getting called with serviceNameNoHash, therefore the comparison should be done for the same. Otherwise, we will have to setup pattern SECA rules with no hash chars.