### PR TITLE
Add support for transformation of elasticsearch data document mappings

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -55,6 +55,7 @@ Written in 2018 by Zhang Wei - zhangwei1979
 Written in 2018 by Nirendra Singh - nirendra10695
 Written in 2018-2019 by Ayman Abi Abdallah - aabiabdallah
 Written in 2019 by Daniel Taylor - danieltaylor-nz
+Written in 2020 by Jacob Barnes - Tellan
 
 ===========================================================================
 
@@ -96,3 +97,4 @@ Written in 2018 by Zhang Wei - zhangwei1979
 Written in 2018 by Nirendra Singh - nirendra10695
 Written in 2018-2019 by Ayman Abi Abdallah - aabiabdallah
 Written in 2019 by Daniel Taylor - danieltaylor-nz
+Written in 2020 by Jacob Barnes - Tellan

--- a/framework/entity/EntityEntities.xml
+++ b/framework/entity/EntityEntities.xml
@@ -106,6 +106,8 @@ along with this software (see the LICENSE.md file). If not, see
         <field name="manualDataServiceName" type="text-medium"><description>Name of a service to call to get additional
             data to include in the document. This service should implement the
             org.moqui.EntityServices.add#ManualDocumentData interface.</description></field>
+        <field name="manualMappingServiceName" type="text-medium"><description>Name of a service to call to alter the generated
+            elasticsearch mapping for the data document </description></field>
 
         <relationship type="many" related="moqui.entity.document.DataDocumentField" short-alias="fields">
             <key-map field-name="dataDocumentId"/></relationship>

--- a/framework/service/org/moqui/EntityServices.xml
+++ b/framework/service/org/moqui/EntityServices.xml
@@ -41,4 +41,14 @@ along with this software (see the LICENSE.md file). If not, see
             <parameter name="document" type="Map"><description>For details see document parameter in receive#DataFeed.</description></parameter>
         </out-parameters>
     </service>
+    <service verb="transform" noun="DocumentMapping" type="interface">
+        <description>Services named in the DataDocument.manualMappingServiceName field should implement this interface.</description>
+        <in-parameters>
+            <parameter name="mapping" type="Map"/>
+        </in-parameters>
+        <out-parameters>
+            <parameter name="mapping" type="Map"/>
+            <parameter name="settings" type="Map"/>
+        </out-parameters>
+    </service>
 </services>

--- a/framework/src/main/groovy/org/moqui/impl/context/ElasticFacadeImpl.groovy
+++ b/framework/src/main/groovy/org/moqui/impl/context/ElasticFacadeImpl.groovy
@@ -241,15 +241,21 @@ class ElasticFacadeImpl implements ElasticFacade {
 
         @Override
         void createIndex(String index, Map docMapping, String alias) {
-            createIndex(index, null, docMapping, alias)
+            createIndex(index, null, docMapping, alias, null)
         }
         void createIndex(String index, String docType, Map docMapping, String alias) {
+            createIndex(index, docType, docMapping, alias, null)
+        }
+        void createIndex(String index, String docType, Map docMapping, String alias, Map settings) {
             RestClient restClient = makeRestClient(Method.PUT, index, null)
             if (docMapping || alias) {
                 Map requestMap = new HashMap()
                 if (docMapping) {
                     if (esVersionUnder7) requestMap.put("mappings", [(docType?:'_doc'):docMapping])
                     else requestMap.put("mappings", docMapping)
+                }
+                if (settings) {
+                    requestMap.put('settings', settings)
                 }
                 if (alias) requestMap.put("aliases", [(alias):[:]])
                 restClient.text(objectToJson(requestMap))
@@ -473,17 +479,26 @@ class ElasticFacadeImpl implements ElasticFacade {
         }
         synchronized protected void storeIndexAndMapping(String indexName, EntityValue dd) {
             String dataDocumentId = (String) dd.getNoCheckSimple("dataDocumentId")
+            String manualMappingServiceName = (String) dd.getNoCheckSimple("manualMappingServiceName")
             String esIndexName = ddIdToEsIndex(dataDocumentId)
 
             // logger.warn("========== Checking index ${esIndexName} with alias ${indexName} , hasIndex=${hasIndex}")
             boolean hasIndex = indexExists(esIndexName)
             Map docMapping = makeElasticSearchMapping(dataDocumentId, ecfi)
+            Map settings = null
+
+            if (manualMappingServiceName) {
+                def serviceResult = ecfi.service.sync().name(manualMappingServiceName).parameter('mapping', docMapping).call()
+                docMapping = (Map) serviceResult.mapping
+                settings = (Map) serviceResult.settings
+            }
+
             if (hasIndex) {
                 logger.info("Updating ElasticSearch index ${esIndexName} for ${dataDocumentId} document mapping")
                 putMapping(esIndexName, dataDocumentId, docMapping)
             } else {
                 logger.info("Creating ElasticSearch index ${esIndexName} for ${dataDocumentId} with alias ${indexName} and adding document mapping")
-                createIndex(esIndexName, dataDocumentId, docMapping, indexName)
+                createIndex(esIndexName, dataDocumentId, docMapping, indexName, settings)
                 // logger.warn("========== Added mapping for ${dataDocumentId} to index ${esIndexName}:\n${docMapping}")
             }
         }


### PR DESCRIPTION
**Problem:**

A problem that's been on our backlog for a long time is sorting results from elasticsearch. Keyword fields are the only fields that can be sorted on natively, and the standard analysis of the fields makes the distinction between "jacob" and "Jacob". Normal string sorting will sort capital letters first, then lowercase. Which means "jacob" will end up at the bottom of the list, miles away from "Jacob".

In order to fix this, the mapping on the index needs to be updated so that the field you sort on is normalized without case. With a [keyword normalizer](https://www.elastic.co/guide/en/elasticsearch/reference/current/normalizer.html) the value of the field remains as it was inputted, but when doing aggregations and sorts, the field uses its normalized version. This is a post that explains how to set up a normalizer to treat keyword values as lowercase:

https://discuss.elastic.co/t/case-insensitive-sort-doesnt-work/143192/7

**Solution(s):**

I considered a few ways to add this mapping into the moqui elastic facade, from most complicated, to most broad:

1. Either create entities or use a json string field to store extra mapping data for fields. There would also need to be a place to hold the "settings" field of the elasticsearch index creation
2. Code the normalizer into ElasticFacade and add a field to DataDocumentField to set the normalizer for that field.
3. Add a field to DataDocument for a manual mapping service that could transform the mapping before ElasticFacade creates the index.

I decided that to make this most re-usable and quick to implement, the third option would handle any possible case. If we decided to model field mappings later, we could also add that on top.

The service takes the normally generated mapping for the index and returns it with the same name and an optional settings map. The settings map gets added to the createIndex request. Unfortunately, in order to update analyzers and normalizers in the index settings, the index [needs to be closed](https://www.elastic.co/guide/en/elasticsearch/reference/7.6/indices-update-settings.html#update-settings-analysis). We could code that, but it would case a little interruption in the index.

Let me know if you have any questions, suggestions, or want to see an example of a use case for this.