### PR TITLE
Enable running embedded ElasticSearch within docker container

### DIFF
--- a/docker/simple/Dockerfile
+++ b/docker/simple/Dockerfile
@@ -17,6 +17,9 @@ COPY execlib execlib
 # always want the runtime directory
 COPY runtime runtime
 
+# create user for elasticsearch and chown corresponding files
+RUN groupadd -r elasticsearch && useradd --no-log-init -r -d /opt/moqui/runtime/elasticsearch -g elasticsearch elasticsearch && chown -R elasticsearch:elasticsearch runtime/elasticsearch
+
 # exposed as volumes for configuration purposes
 VOLUME ["/opt/moqui/runtime/conf", "/opt/moqui/runtime/lib", "/opt/moqui/runtime/classes", "/opt/moqui/runtime/ecomponent"]
 # exposed as volumes to persist data outside the container, recommended

--- a/framework/src/start/java/MoquiStart.java
+++ b/framework/src/start/java/MoquiStart.java
@@ -478,7 +478,7 @@ public class MoquiStart {
                     boolean elasticsearchOwner = Files.getOwner(Paths.get(runtimePath, "elasticsearch")).getName().equals("elasticsearch");
                     boolean suAble = Runtime.getRuntime().exec(new String[]{"/bin/su", "-c", "/bin/true", "elasticsearch"}).waitFor() == 0;
                     if (elasticsearchOwner && suAble) command = new String[]{"su", "-c", "./bin/elasticsearch", "elasticsearch"};
-                } catch (java.io.IOException e) {}
+                } catch (IOException e) {}
             }
             ProcessBuilder pb = new ProcessBuilder(command);
             pb.redirectErrorStream(true);

--- a/framework/src/start/java/MoquiStart.java
+++ b/framework/src/start/java/MoquiStart.java
@@ -17,6 +17,8 @@ import java.lang.reflect.Array;
 import java.lang.reflect.Method;
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.nio.file.Files;
+import java.nio.file.Paths;
 import java.security.CodeSource;
 import java.security.ProtectionDomain;
 import java.security.cert.Certificate;
@@ -471,7 +473,12 @@ public class MoquiStart {
             if (isWindows) {
                 command = new String[] {"cmd.exe", "/c", "bin\\elasticsearch.bat"};
             } else {
-                command = new String[] {"./bin/elasticsearch"};
+                command = new String[]{"./bin/elasticsearch"};
+                try {
+                    boolean elasticsearchOwner = Files.getOwner(Paths.get(runtimePath, "elasticsearch")).getName().equals("elasticsearch");
+                    boolean suAble = Runtime.getRuntime().exec(new String[]{"/bin/su", "-c", "/bin/true", "elasticsearch"}).waitFor() == 0;
+                    if (elasticsearchOwner && suAble) command = new String[]{"su", "-c", "./bin/elasticsearch", "elasticsearch"};
+                } catch (java.io.IOException e) {}
             }
             ProcessBuilder pb = new ProcessBuilder(command);
             pb.redirectErrorStream(true);


### PR DESCRIPTION
Docker runs its processes as root by default, which is not allowed by ElasticSearch. In order to enable the embedded ElasticSearch to be run, it needs to run as a different user.
This patch includes preparing the docker container by creating a user+group that owns the runtime/elasticsearch directory and upon startup checking whether the external ElasticSearch process has to be executed on behalf of the elasticsearch user, checking that:
1. the directory is owned by the elasticsearch user
2. the current user can issue a "su -c" user to execute a command as the elasticsearch user (implies that the user is root and elasticsearch user exists)