### PR TITLE
Enable Accept content-type to be different from sent content-type in RestClient requests

### DIFF
--- a/moqui-util/src/main/java/org/moqui/util/RestClient.java
+++ b/moqui-util/src/main/java/org/moqui/util/RestClient.java
@@ -88,6 +88,7 @@ public class RestClient {
     private String uriString = null;
     private Method method = Method.GET;
     private String contentType = "application/json";
+    private String acceptContentType = null;
     private Charset charset = StandardCharsets.UTF_8;
     private String bodyText = null;
     private MultiPartContentProvider multiPart = null;
@@ -131,6 +132,11 @@ public class RestClient {
     /** Defaults to 'application/json', could also be 'text/xml', etc */
     public RestClient contentType(String contentType) {
         this.contentType = contentType;
+        return this;
+    }
+
+    public RestClient acceptContentType(String acceptContentType) {
+        this.acceptContentType = acceptContentType;
         return this;
     }
 
@@ -343,7 +349,7 @@ public class RestClient {
             // not needed, set by call to request.content() with passed contentType: request.header(HttpHeader.CONTENT_TYPE, contentType);
         }
 
-        request.accept(contentType);
+        request.accept(acceptContentType == null? contentType: acceptContentType);
 
         if (logger.isTraceEnabled())
             logger.trace("RestClient request " + request.getMethod() + " " + request.getURI() + " Headers: " + request.getHeaders());


### PR DESCRIPTION
This pull request adds an acceptContentType that, when set, overrides the contentType used for the sent message to also be used as the contentType that is being accepted in the response.
Primary motivation is to use the RestClient to also fetch the bearer token in a OAuth2 authorization. The AWS Cognito implementation (https://docs.aws.amazon.com/cognito/latest/developerguide/token-endpoint.html) for instance requires the sent contentType to be 'application/x-www-form-urlencoded' but the response is application/json so when the RestClient adds the same contentType as the Accept header, the request fails.
While it is not necessary to use RestClient to get the token, it keeps the code simpler avoiding the need to add a second way of performing an http request within the context of a REST integration.