### PR TITLE
Add support for try/catch/finally in XmlActions

### DIFF
--- a/framework/template/XmlActions.groovy.ftl
+++ b/framework/template/XmlActions.groovy.ftl
@@ -305,6 +305,19 @@ ${.node}
 
 </#macro>
 
+<#macro try>  try {
+    <#recurse .node/>
+    }<#if .node["catch"]?has_content><#list .node["catch"] as catch> catch (<#if catch.@class?has_content>${catch.@class}<#else>Throwable</#if><#if catch.@field?has_content> ${catch.@field}<#else> e</#if>) {
+    <#recurse catch/>
+    }</#list>
+    <#if .node["finally"]?has_content> finally {
+        <#recurse .node["finally"][0]/>
+        }</#if></#if>
+</#macro>
+
+<#macro catch><#-- do nothing when visiting, only used explicitly inline --></#macro>
+<#macro finally><#-- do nothing when visiting, only used explicitly inline --></#macro>
+
 <#-- =================== if/when sub-elements =================== -->
 
 <#macro condition><#-- do nothing when visiting, only used explicitly inline --></#macro>

--- a/framework/xsd/xml-actions-2.1.xsd
+++ b/framework/xsd/xml-actions-2.1.xsd
@@ -945,6 +945,32 @@ along with this software (see the LICENSE.md file). If not, see
         </xs:complexType>
     </xs:element>
 
+    <xs:element name="try" substitutionGroup="ControlOperations">
+        <xs:annotation><xs:documentation>
+            The try element can be used to catch errors
+        </xs:documentation></xs:annotation>
+        <xs:complexType>
+            <xs:sequence>
+                <xs:group minOccurs="0" maxOccurs="unbounded" ref="AllOperations"/>
+                <xs:element maxOccurs="unbounded" ref="catch"/>
+                <xs:element minOccurs="0" ref="finally"/>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+    <xs:element name="finally">
+        <xs:annotation><xs:documentation>The finally block is executed after the catch block</xs:documentation></xs:annotation>
+        <xs:complexType>
+            <xs:group minOccurs="0" maxOccurs="unbounded" ref="AllOperations"/>
+        </xs:complexType>
+    </xs:element>
+    <xs:element name="catch">
+        <xs:annotation><xs:documentation>Catches an exception</xs:documentation></xs:annotation>
+        <xs:complexType>
+            <xs:group minOccurs="0" maxOccurs="unbounded" ref="AllOperations"/>
+            <xs:attribute name="class" type="xs:string"/>
+            <xs:attribute name="field" type="xs:string"/>
+        </xs:complexType>
+    </xs:element>
 
     <xs:group name="IfConditions">
         <xs:choice>


### PR DESCRIPTION
XmlActions does not have try/catch/finally tags. This is trivial to workaround using a script tag. The codebase itself does it in `Wikiservices.xml` and `SystemMessageServices.xml`. I reckon this change might have been considered before, so are there any reasons we don't have try/catch/finally tags? It should help reducing the usage of script tags and it's syntactially easier to read as if doesn't require code-switching