### PR TITLE
Added new add-unique-as database configuration attribute

### DIFF
--- a/framework/src/main/groovy/org/moqui/impl/entity/EntityFindBuilder.java
+++ b/framework/src/main/groovy/org/moqui/impl/entity/EntityFindBuilder.java
@@ -55,7 +55,7 @@ public class EntityFindBuilder extends EntityQueryBuilder {
         if (isGroupBy || (isDistinct && fiaLength > 0)) {
             sqlTopLevel.append("COUNT(*) FROM (SELECT ");
             if (isDistinct) sqlTopLevel.append("DISTINCT ");
-            makeSqlSelectFields(fieldInfoArray, fieldOptionsArray, true);
+            makeSqlSelectFields(fieldInfoArray, fieldOptionsArray, efi.getDatabaseNode(this.mainEntityDefinition.groupName).attribute("add-unique-as").equals("true"));
             // NOTE: this will be closed by closeCountSubSelect()
         } else {
             if (isDistinct) {

--- a/framework/src/main/groovy/org/moqui/impl/entity/EntityFindImpl.java
+++ b/framework/src/main/groovy/org/moqui/impl/entity/EntityFindImpl.java
@@ -56,7 +56,7 @@ public class EntityFindImpl extends EntityFindBase {
         efb.isFineOne();
 
         // SELECT fields
-        efb.makeSqlSelectFields(fieldInfoArray, fieldOptionsArray, false);
+        efb.makeSqlSelectFields(fieldInfoArray, fieldOptionsArray, efi.getDatabaseNode(entityDef.groupName).attribute("add-unique-as").equals("true"));
         // FROM Clause
         efb.makeSqlFromClause();
         // WHERE clause only for one/pk query
@@ -117,7 +117,7 @@ public class EntityFindImpl extends EntityFindBase {
         if (getDistinct()) efb.makeDistinct();
 
         // select fields
-        efb.makeSqlSelectFields(fieldInfoArray, fieldOptionsArray, false);
+        efb.makeSqlSelectFields(fieldInfoArray, fieldOptionsArray, efi.getDatabaseNode(this.entityDef.groupName).attribute("add-unique-as").equals("true"));
         // FROM Clause
         efb.makeSqlFromClause();
         // WHERE clause

--- a/framework/src/main/groovy/org/moqui/impl/entity/EntityValueImpl.java
+++ b/framework/src/main/groovy/org/moqui/impl/entity/EntityValueImpl.java
@@ -218,7 +218,7 @@ public class EntityValueImpl extends EntityValueBase {
         StringBuilder sql = eqb.sqlTopLevel;
         sql.append("SELECT ");
         // NOTE: cast here is needed to resolve compile warning, even if there may be a IDE warning
-        eqb.makeSqlSelectFields(allFieldArray, null, false);
+        eqb.makeSqlSelectFields(allFieldArray, null, efi.getDatabaseNode(getEntityDefinition().groupName).attribute("add-unique-as").equals("true"));
 
         sql.append(" FROM ").append(ed.getFullTableName()).append(" WHERE ");
 

--- a/framework/src/main/resources/MoquiDefaultConf.xml
+++ b/framework/src/main/resources/MoquiDefaultConf.xml
@@ -593,7 +593,7 @@
             <inline-jdbc jdbc-uri="jdbc:h2:${moqui_runtime}/db/h2/moqui;lock_timeout=30000" jdbc-username="sa" jdbc-password="sa"/>
         </datasource>
         -->
-        <database name="h2" use-pk-constraint-names="false" use-indexes-unique="true" default-isolation-level="ReadCommitted"
+        <database name="h2" use-pk-constraint-names="false" use-indexes-unique="true" add-unique-as="true" default-isolation-level="ReadCommitted"
                 default-jdbc-driver="org.h2.Driver" default-xa-ds-class="org.h2.jdbcx.JdbcDataSource"
                 default-start-server-args="-tcpPort 9092 -ifExists -baseDir ${moqui_runtime}/db/h2">
             <inline-jdbc><xa-properties url="${entity_ds_url}" user="${entity_ds_user}" password="${entity_ds_password}"/></inline-jdbc>
@@ -750,7 +750,7 @@
             <inline-jdbc jdbc-uri="jdbc:oracle:thin:@127.0.0.1:1521:moqui" jdbc-username="moqui" jdbc-password="moqui"/>
         </datasource>
         -->
-        <database name="oracle" join-style="ansi" from-lateral-style="apply" default-isolation-level="ReadCommitted"
+        <database name="oracle" add-unique-as="true" join-style="ansi" from-lateral-style="apply" default-isolation-level="ReadCommitted"
                 default-test-query="SELECT 1 FROM DUAL" default-jdbc-driver="oracle.jdbc.driver.OracleDriver"
                 default-xa-ds-class="oracle.jdbc.xa.client.OracleXADataSource"
                 default-startup-add-missing="true" default-runtime-add-missing="false">

--- a/framework/xsd/moqui-conf-2.1.xsd
+++ b/framework/xsd/moqui-conf-2.1.xsd
@@ -774,6 +774,7 @@ along with this software (see the LICENSE.md file). If not, see
                     </xs:annotation></xs:enumeration>
                 </xs:restriction></xs:simpleType>
             </xs:attribute>
+            <xs:attribute name="add-unique-as" default="false" type="boolean"/>
             <xs:attribute name="always-use-constraint-keyword" default="false" type="boolean"/>
             <xs:attribute name="use-schema-for-all" default="false" type="boolean">
                 <xs:annotation><xs:documentation>Set to true to include the schema name for primary keys, foreign keys, and indexes.</xs:documentation></xs:annotation>


### PR DESCRIPTION
The current hardcoded behaviour was failing on certain view-entities in Oracle 12c (12.1.0.2.0)