### PR TITLE
Exposed the parameters in the update password service

### DIFF
--- a/framework/service/org/moqui/impl/UserServices.xml
+++ b/framework/service/org/moqui/impl/UserServices.xml
@@ -118,8 +118,14 @@ along with this software (see the LICENSE.md file). If not, see
             <parameter name="newPassword" required="true"/>
             <parameter name="newPasswordVerify" required="true"/>
         </in-parameters>
+        <out-parameters>
+            <parameter name="passwordIssues" type="Boolean"/>
+            <parameter name="updateSuccessful" type="Boolean"/>
+        </out-parameters>
         <actions>
             <set field="hasPwAdminPermission" from="ec.user.hasPermission('ADMIN_PASSWORD')"/>
+            <set field="passwordIssues" from="false"/>
+            <set field="updateSuccessful" from="false"/>
 
             <if condition="userId"><then>
                 <entity-find-one entity-name="moqui.security.UserAccount" value-field="userAccount"/>
@@ -161,9 +167,9 @@ along with this software (see the LICENSE.md file). If not, see
                 </if>
             </if>
 
-            <service-call name="org.moqui.impl.UserServices.update#PasswordInternal" out-map="updateOut"
+            <service-call name="org.moqui.impl.UserServices.update#PasswordInternal" out-map="context"
                     in-map="[userId:userId, newPassword:newPassword, newPasswordVerify:newPasswordVerify]"/>
-            <if condition="updateOut.updateSuccessful &amp;&amp; !ec.message.hasError()">
+            <if condition="updateSuccessful &amp;&amp; !ec.message.hasError()">
                 <message public="true" type="success">Password updated for user ${userAccount.username}</message></if>
         </actions>
     </service>


### PR DESCRIPTION
Exposed the passwordIssues and updateSuccessful parameters in the update password service. These come in handy when the update password service is called from a RESTful API so that the rest client can know whether the request was successful or not. 

Currently, the rest client have no way to determine if a password change was successful except by inspecting the response message. This becomes more challenging when message is localized or changed.