### PR TITLE
Not able to use api_key

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -101,5 +101,6 @@ Written in 2018-2020 by Ayman Abi Abdallah - aabiabdallah
 Written in 2019 by Daniel Taylor - danieltaylor-nz
 Written in 2020 by Jacob Barnes - Tellan
 Written in 2020 by Amir Anjomshoaa - amiranjom
+Written in 2021 by Deepak Dixit - dixitdeepak
 
 ===========================================================================

--- a/AUTHORS
+++ b/AUTHORS
@@ -57,6 +57,7 @@ Written in 2018-2020 by Ayman Abi Abdallah - aabiabdallah
 Written in 2019 by Daniel Taylor - danieltaylor-nz
 Written in 2020 by Jacob Barnes - Tellan
 Written in 2020 by Amir Anjomshoaa - amiranjom
+Written in 2021 by Deepak Dixit - dixitdeepak
 
 ===========================================================================
 

--- a/framework/src/main/groovy/org/moqui/impl/context/UserFacadeImpl.groovy
+++ b/framework/src/main/groovy/org/moqui/impl/context/UserFacadeImpl.groovy
@@ -768,7 +768,7 @@ class UserFacadeImpl implements UserFacade {
         // save hashed in UserLoginKey, calc expire and set from/thru dates
         String hashedKey = eci.ecfi.getSimpleHash(loginKey, "", eci.ecfi.getLoginKeyHashType(), false)
         Timestamp fromDate = getNowTimestamp()
-        long thruTime = Math.round(fromDate.getTime() + (expireHours * 60*60*1000))
+        long thruTime = (long) (fromDate.getTime() + (expireHours * 60*60*1000))
         eci.serviceFacade.sync().name("create", "moqui.security.UserLoginKey")
                 .parameters([loginKey:hashedKey, userId:userId, fromDate:fromDate, thruDate:new Timestamp(thruTime)])
                 .disableAuthz().requireNewTransaction(true).call()

--- a/framework/src/main/groovy/org/moqui/impl/context/UserFacadeImpl.groovy
+++ b/framework/src/main/groovy/org/moqui/impl/context/UserFacadeImpl.groovy
@@ -768,7 +768,7 @@ class UserFacadeImpl implements UserFacade {
         // save hashed in UserLoginKey, calc expire and set from/thru dates
         String hashedKey = eci.ecfi.getSimpleHash(loginKey, "", eci.ecfi.getLoginKeyHashType(), false)
         Timestamp fromDate = getNowTimestamp()
-        long thruTime = (long) (fromDate.getTime() + (expireHours * 60*60*1000))
+        long thruTime = fromDate.getTime() + Math.round(expireHours * 60*60*1000)
         eci.serviceFacade.sync().name("create", "moqui.security.UserLoginKey")
                 .parameters([loginKey:hashedKey, userId:userId, fromDate:fromDate, thruDate:new Timestamp(thruTime)])
                 .disableAuthz().requireNewTransaction(true).call()


### PR DESCRIPTION
Fix truncation error while type casting, Math.round returned incorrect value, and due to this thruDate set as prior date (1970-01-26 02:01:23.647). As per getLoginKey implementation it deletes the old expired login key, as thru date was set as before fromDate it delete the UserLoginKey record immediately.

The changes was one at commit https://github.com/moqui/moqui-framework/commit/4b7c7e70aab19ba5a362ed73cef0fcab65a34f49