### PR TITLE
Avoid adding auto entity columns when an explicit layout or column definition is present

### DIFF
--- a/framework/src/main/groovy/org/moqui/impl/screen/ScreenForm.groovy
+++ b/framework/src/main/groovy/org/moqui/impl/screen/ScreenForm.groovy
@@ -217,8 +217,8 @@ class ScreenForm {
             }
         }
 
-        // for form-list auto add entity columns
-        if (fieldColumnInfo != null && fieldColumnInfo.size() > 0) {
+        // for form-list auto add entity columns if no explicit field-layout or columns definition is present
+        if (!baseFormNode.first("field-layout") && !baseFormNode.first("columns") && fieldColumnInfo != null && fieldColumnInfo.size() > 0) {
             for (Map.Entry<String, ArrayList<String>> curInfo in fieldColumnInfo.entrySet()) {
                 addAutoEntityColumns(newFormNode, baseFormNode, curInfo.getKey(), curInfo.getValue())
             }

--- a/framework/src/main/groovy/org/moqui/impl/screen/ScreenForm.groovy
+++ b/framework/src/main/groovy/org/moqui/impl/screen/ScreenForm.groovy
@@ -218,7 +218,7 @@ class ScreenForm {
         }
 
         // for form-list auto add entity columns if no explicit field-layout or columns definition is present
-        if (!baseFormNode.first("field-layout") && !baseFormNode.first("columns") && fieldColumnInfo != null && fieldColumnInfo.size() > 0) {
+        if (!baseFormNode.first("form-list-column") && !baseFormNode.first("columns") && fieldColumnInfo != null && fieldColumnInfo.size() > 0) {
             for (Map.Entry<String, ArrayList<String>> curInfo in fieldColumnInfo.entrySet()) {
                 addAutoEntityColumns(newFormNode, baseFormNode, curInfo.getKey(), curInfo.getValue())
             }


### PR DESCRIPTION
Check whether an explicit field-layout or columns definition is defined for a form-list before adding auto columns which would re-arrange the explicit definition and even duplicate columns within the form.