### PR TITLE
Add auto-fields-entity.@auto-columns attribute

### DIFF
--- a/framework/src/main/groovy/org/moqui/impl/screen/ScreenForm.groovy
+++ b/framework/src/main/groovy/org/moqui/impl/screen/ScreenForm.groovy
@@ -173,6 +173,7 @@ class ScreenForm {
                 throw new BaseArtifactException("Cound not find service [${serviceName}] or entity noun referred to in auto-fields-service of form [${newFormNode.attribute("name")}] of screen [${sd.location}]")
             } else if (formSubNode.name == "auto-fields-entity") {
                 String entityName = formSubNode.attribute("entity-name")
+                Boolean addAutoColumns = !"false".equals(formSubNode.attribute("auto-columns"))
 
                 if (isDynamic) {
                     entityName = ecfi.resourceFacade.expandNoL10n(entityName, null)
@@ -190,7 +191,7 @@ class ScreenForm {
                         excludes.add(excludeNode.attribute("field-name"))
                     }
                     addEntityFields(ed, formSubNode.attribute("include")?:"all",
-                            formSubNode.attribute("field-type")?:"find-display", excludes, newFormNode, fieldColumnInfo)
+                            formSubNode.attribute("field-type")?:"find-display", excludes, newFormNode, addAutoColumns ? fieldColumnInfo : null)
                 } else {
                     throw new BaseArtifactException("Cound not find entity [${entityName}] referred to in auto-fields-entity of form [${newFormNode.attribute("name")}] of screen [${sd.location}]")
                 }

--- a/framework/xsd/xml-form-2.1.xsd
+++ b/framework/xsd/xml-form-2.1.xsd
@@ -363,6 +363,7 @@ along with this software (see the LICENSE.md file). If not, see
             </xs:simpleType>
         </xs:attribute>
         <xs:attribute name="field-type" default="find-display" type="auto-field-type"/>
+        <xs:attribute name="auto-columns" default="true" type="boolean"/>
     </xs:complexType></xs:element>
     <xs:element name="field-layout"><xs:complexType>
         <xs:choice minOccurs="0" maxOccurs="unbounded">


### PR DESCRIPTION
When using auto-fields-entity to add fields to a form that also has a static definition for columns or field-layout, the behavior of the new automatic column generation is to add all columns, disregarding fields that should be ignored (not referenced explicitly in a field-layout that has no fields-not-referenced tag), and duplicating columns that have a different static definition.
When this new auto-fields-entity.@auto-columns is set to "false", the fields generated for this entity will not be added as columns.