### PR TITLE
fix: apply screen.@transaction-timeout

### DIFF
--- a/framework/src/main/groovy/org/moqui/impl/screen/ScreenUrlInfo.groovy
+++ b/framework/src/main/groovy/org/moqui/impl/screen/ScreenUrlInfo.groovy
@@ -610,7 +610,7 @@ class ScreenUrlInfo {
             if (curSd.screenNode?.attribute('begin-transaction') == "true") this.beginTransaction = true
             String curTxTimeoutAttr = curSd.screenNode?.attribute("transaction-timeout")
             if (curTxTimeoutAttr) {
-                Integer curTransactionTimeout = Integer.parseInt(txTimeoutAttr)
+                Integer curTransactionTimeout = Integer.parseInt(curTxTimeoutAttr)
                 if (transactionTimeout == null || curTransactionTimeout > transactionTimeout)
                     transactionTimeout = curTransactionTimeout
             }
@@ -711,7 +711,7 @@ class ScreenUrlInfo {
             if (curSd.screenNode?.attribute('begin-transaction') == "true") this.beginTransaction = true
             String curTxTimeoutAttr = curSd.screenNode?.attribute("transaction-timeout")
             if (curTxTimeoutAttr) {
-                Integer curTransactionTimeout = Integer.parseInt(txTimeoutAttr)
+                Integer curTransactionTimeout = Integer.parseInt(curTxTimeoutAttr)
                 if (transactionTimeout == null || curTransactionTimeout > transactionTimeout)
                     transactionTimeout = curTransactionTimeout
             }


### PR DESCRIPTION
Fix problem resulting in transaction-timeout in a screen definition never being applied (was always null, thus using the default value), due to 2 separate issues:
1. the String variable with the attribute value is curTxTimeoutAttr, but was attempted to be accessed using the txTimeoutAttr variable name
2. The String to Integer conversion was attempted using the Integer.getInteger() method, which is intended to get a value from the System Properties, not to parse the String which is the intended behavior according to the XSD for this attribute.