### PR TITLE
fix: typo in variable name for transaction-timeout

### DIFF
--- a/framework/src/main/groovy/org/moqui/impl/screen/ScreenUrlInfo.groovy
+++ b/framework/src/main/groovy/org/moqui/impl/screen/ScreenUrlInfo.groovy
@@ -610,7 +610,7 @@ class ScreenUrlInfo {
             if (curSd.screenNode?.attribute('begin-transaction') == "true") this.beginTransaction = true
             String curTxTimeoutAttr = curSd.screenNode?.attribute("transaction-timeout")
             if (curTxTimeoutAttr) {
-                Integer curTransactionTimeout = Integer.parseInt(txTimeoutAttr)
+                Integer curTransactionTimeout = Integer.parseInt(curTxTimeoutAttr)
                 if (transactionTimeout == null || curTransactionTimeout > transactionTimeout)
                     transactionTimeout = curTransactionTimeout
             }
@@ -711,7 +711,7 @@ class ScreenUrlInfo {
             if (curSd.screenNode?.attribute('begin-transaction') == "true") this.beginTransaction = true
             String curTxTimeoutAttr = curSd.screenNode?.attribute("transaction-timeout")
             if (curTxTimeoutAttr) {
-                Integer curTransactionTimeout = Integer.parseInt(txTimeoutAttr)
+                Integer curTransactionTimeout = Integer.parseInt(curTxTimeoutAttr)
                 if (transactionTimeout == null || curTransactionTimeout > transactionTimeout)
                     transactionTimeout = curTransactionTimeout
             }


### PR DESCRIPTION
Fix the issue left out in commit https://github.com/moqui/moqui-framework/commit/3fda7599a83ea6d8d42332db19eaa1711a8b433c:
the String variable with the attribute value is curTxTimeoutAttr, but was attempted to be accessed using the txTimeoutAttr variable name