### PR TITLE
fix: in ScreenForm.groovy, localize static option.@text that does not need expansion

### DIFF
--- a/framework/src/main/groovy/org/moqui/impl/screen/ScreenForm.groovy
+++ b/framework/src/main/groovy/org/moqui/impl/screen/ScreenForm.groovy
@@ -1225,7 +1225,10 @@ class ScreenForm {
                 String key = childNode.attribute('key')
                 if (key != null && key.contains('${')) key = ec.resource.expandNoL10n(key, null)
                 String text = childNode.attribute('text')
-                if (text != null && text.contains('${')) text = ec.resource.expand(text, null)
+                if (text != null && text.contains('${'))
+                    text = ec.resource.expand(text, null)
+                else
+                    text = ec.l10n.localize(text)
                 options.put(key, text ?: ec.l10n.localize(key))
             }
         }


### PR DESCRIPTION
There was a case left out in localizing options, and it is when a static option is added that does not need expansion for its option.@text attribute.
Not sure whether this solution is the preferred one for performance reasons (expand if the attribute contains the '${' substring, just localize otherwise), or just plainly expand regardless of the '${' substring, which will also localize.