### PR TITLE
fix: always expand non-null option.@text attribute, which will also localize the string

### DIFF
--- a/framework/src/main/groovy/org/moqui/impl/screen/ScreenForm.groovy
+++ b/framework/src/main/groovy/org/moqui/impl/screen/ScreenForm.groovy
@@ -1226,7 +1226,7 @@ class ScreenForm {
                 String key = childNode.attribute('key')
                 if (key != null && key.contains('${')) key = ec.resource.expandNoL10n(key, null)
                 String text = childNode.attribute('text')
-                if (text != null && text.contains('${')) text = ec.resource.expand(text, null)
+                if (text != null) text = ec.resource.expand(text, null)
                 options.put(key, text ?: ec.l10n.localize(key))
             }
         }


### PR DESCRIPTION
There was a case left out in localizing options, and it is when a static option is added that does not need expansion for its option.@text attribute.
This is the agreed solution of PR https://github.com/moqui/moqui-framework/pull/465