### PR TITLE
add gradle task to enable setting up intellij XML catalog

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -58,6 +58,7 @@ Written in 2019 by Daniel Taylor - danieltaylor-nz
 Written in 2020 by Jacob Barnes - Tellan
 Written in 2020 by Amir Anjomshoaa - amiranjom
 Written in 2021 by Deepak Dixit - dixitdeepak
+Written in 2021 by Taher Alkhateeb - pythys
 
 ===========================================================================
 
@@ -102,5 +103,6 @@ Written in 2019 by Daniel Taylor - danieltaylor-nz
 Written in 2020 by Jacob Barnes - Tellan
 Written in 2020 by Amir Anjomshoaa - amiranjom
 Written in 2021 by Deepak Dixit - dixitdeepak
+Written in 2021 by Taher Alkhateeb - pythys
 
 ===========================================================================

--- a/build.gradle
+++ b/build.gradle
@@ -173,6 +173,38 @@ task stopElasticSearch { doLast {
     }
 } }
 
+// ========== development tasks ==========
+task setupIntellij {
+    description "Adds all XML catalog items to intellij to enable autocomplete"
+    doLast {
+        def ideaDir = "${rootDir}/.idea"
+        def xsdDir = "${rootDir}/framework/xsd"
+        def parser = new XmlSlurper()
+        parser.setFeature("http://apache.org/xml/features/disallow-doctype-decl", false)
+        parser.setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", false)
+        def xmlCatalog = parser.parse(file("${xsdDir}/framework-catalog.xml"))
+        def builder = new groovy.xml.StreamingMarkupBuilder()
+        builder.encoding = 'UTF-8'
+        def rawXml = builder.bind {
+            project(version: '4') {
+                component(name: 'ExternalStorageConfigurationManager', enabled: true)
+                component(name: 'ProjectResources') {
+                    xmlCatalog.system.each { entry ->
+                        resource(
+                            url: entry.@systemId,
+                            location: "\$PROJECT_DIR\$/framework/xsd/${entry.@uri}"
+                        )
+                    }
+                }
+            }
+        }
+        def misc = groovy.xml.XmlUtil.serialize(rawXml)
+        delete "${ideaDir}/misc.xml"
+        mkdir ideaDir
+        new File("${ideaDir}/misc.xml").write(misc)
+    }
+}
+
 // ========== test task ==========
 // NOTE1: to run startElasticSearch before the first test task add it as a dependency to all test tasks
 // NOTE2: to run stopElasticSearch after the last test task make all test tasks finalizedBy stopElasticSearch


### PR DESCRIPTION
This task is a convenience task to allow developers to start developing immediately without having to manually configure the catalog items one-by-one which is a little tedious