### PR TITLE
Squash commit for Add Second Factor Authentication to Moqui project

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -35,6 +35,7 @@ that are otherwise encumbered.
 Signed by git commit adding my legal name and git username:
 
 Written in 2010-2020 by David E. Jones - jonesde
+Written in 2021-2021 by D. Michael Jones - acetousk
 Written in 2014-2015 by Solomon Bessire - sbessire
 Written in 2014-2015 by Jacopo Cappellato - jacopoc
 Written in 2014-2015 by Abdullah Shaikh - abdullahs
@@ -81,6 +82,7 @@ litigation is filed.
 Signed by git commit adding my legal name and git username:
 
 Written in 2010-2020 by David E. Jones - jonesde
+Written in 2021-2021 by D. Michael Jones - acetousk
 Written in 2014-2015 by Solomon Bessire - sbessire
 Written in 2014-2015 by Jacopo Cappellato - jacopoc
 Written in 2014-2015 by Yao Chunlin - chunlinyao

--- a/build.gradle
+++ b/build.gradle
@@ -371,7 +371,7 @@ task gitTagAll {
         boolean pushTags = (project.hasProperty('push') && push == 'true')
 
         // Users can simply push tags to the remote
-        if (tagName == null && pushTags == false) 
+        if (tagName == null && pushTags == false)
             throw new InvalidUserDataException("No tag property specified (use -Ptag=...) and No push tag specified (use -Ppush=true)")
 
         List<String> gitDirectories = []
@@ -421,7 +421,7 @@ task gitTagAll {
 task gitDiffTagsAll {
     description "Do a git diff between two tags in the currently checked out branch in moqui, runtime, and each installed component"
     doLast {
-        if (!project.hasProperty('taga') || taga == null) 
+        if (!project.hasProperty('taga') || taga == null)
             throw new InvalidUserDataException("No taga property specified (use -Ptaga=...)")
 
         // If tagb is not passed, we assume HEAD
@@ -447,7 +447,7 @@ task gitDiffTagsAll {
             logger.lifecycle("${relativePath}")
 
             if ((taga == "HEAD" || tagaCommit != null) && (tagb == "HEAD" || tagbCommit != null)) {
-                grgit.log { 
+                grgit.log {
                     range taga, tagb
                 }.each {
                     logger.lifecycle("    ${it.abbreviatedId} - ${it.shortMessage}")

--- a/framework/build.gradle
+++ b/framework/build.gradle
@@ -129,6 +129,9 @@ dependencies {
     // compile 'javax.resource:connector-api:1.5'
     // compile 'javax.jms:jms:1.1'
 
+    // Java TOTP
+    compile 'dev.samstevens.totp:totp:1.7.1' // MIT
+
     // H2 Database
     compile 'com.h2database:h2:1.4.200' // MPL 2.0, EPL 1.0
 

--- a/framework/data/MoquiSetupData.xml
+++ b/framework/data/MoquiSetupData.xml
@@ -17,6 +17,19 @@ along with this software (see the LICENSE.md file). If not, see
     <moqui.basic.email.EmailTemplate emailTemplateId="PASSWORD_RESET" description="Default Password Reset" emailServerId="SYSTEM"
             emailTypeEnumId="EMT_PWD_RESET" bodyScreenLocation="classpath://screen/PasswordReset.xml" webappName="webroot"
             fromAddress="" ccAddresses="" bccAddresses="" subject="Password Reset" sendPartial="Y"/>
+    <!-- EmailTemplate for single use codes -->
+    <moqui.basic.email.EmailTemplate emailTemplateId="SINGLE_USE_CODE" description="Send single use code" emailServerId="SYSTEM"
+            emailTypeEnumId="EMT_SINGLE_USE_CODE" bodyScreenLocation="classpath://screen/SingleUseCode.xml" webappName="webroot"
+            fromAddress="" ccAddresses="" bccAddresses="" subject="Single Use Code" sendPartial="Y"/>
+    <!-- EmailTemplate for Added Email Authentication Type -->
+    <moqui.basic.email.EmailTemplate emailTemplateId="ADDED_EMAIL_AUTHC_FACTOR" description="Added Email Authentication Type" emailServerId="SYSTEM"
+            emailTypeEnumId="EMT_ADDED_EMAIL_AUTHC_FACTOR" bodyScreenLocation="classpath://screen/AddedEmailAuthcFactor.xml" webappName="webroot"
+            fromAddress="" ccAddresses="" bccAddresses="" subject="Added Email Authentication Type" sendPartial="Y"/>
+    <!-- EmailTemplate for Email Authentication Code Sent -->
+    <moqui.basic.email.EmailTemplate emailTemplateId="EMAIL_AUTHC_FACTOR_SENT" description="Email Authentication Code Sent" emailServerId="SYSTEM"
+            emailTypeEnumId="EMT_EMAIL_AUTHC_FACTOR_SENT" bodyScreenLocation="classpath://screen/EmailAuthcFActorSent.xml" webappName="webroot"
+            fromAddress="" ccAddresses="" bccAddresses="" subject="Email Authentication Code Sent" sendPartial="Y"/>
+
     <!-- EmailTemplate for general notifications -->
     <moqui.basic.email.EmailTemplate emailTemplateId="NOTIFICATION" description="Default Notification" emailServerId="SYSTEM"
             emailTypeEnumId="EMT_NOTIFICATION" bodyScreenLocation="classpath://screen/NotificationEmail.xml" webappName="webroot"

--- a/framework/entity/BasicEntities.xml
+++ b/framework/entity/BasicEntities.xml
@@ -579,6 +579,9 @@ along with this software (see the LICENSE.md file). If not, see
             <moqui.basic.EnumerationType description="Email Type" enumTypeId="EmailType"/>
             <moqui.basic.Enumeration description="System" enumId="EMT_SYSTEM" enumTypeId="EmailType"/>
             <moqui.basic.Enumeration description="Password Reset" enumId="EMT_PWD_RESET" parentEnumId="EMT_SYSTEM" enumTypeId="EmailType"/>
+            <moqui.basic.Enumeration description="Single Use Code" enumId="EMT_SINGLE_USE_CODE" parentEnumId="EMT_SYSTEM" enumTypeId="EmailType"/>
+            <moqui.basic.Enumeration description="Added Email Authentication Type" enumId="EMT_ADDED_EMAIL_AUTHC_FACTOR" parentEnumId="EMT_SYSTEM" enumTypeId="EmailType"/>
+            <moqui.basic.Enumeration description="Email Authentication Code Sent" enumId="EMT_EMAIL_AUTHC_FACTOR_SENT" parentEnumId="EMT_SYSTEM" enumTypeId="EmailType"/>
             <moqui.basic.Enumeration description="Notification" enumId="EMT_NOTIFICATION" parentEnumId="EMT_SYSTEM" enumTypeId="EmailType"/>
             <moqui.basic.Enumeration description="Screen Render" enumId="EMT_SCREEN_RENDER" parentEnumId="EMT_SYSTEM" enumTypeId="EmailType"/>
             <!-- <moqui.basic.Enumeration description="Error Notice" enumId="EMT_ERROR_NOTICE" parentEnumId="EMT_SYSTEM" enumTypeId="EmailType"/> -->

--- a/framework/entity/SecurityEntities.xml
+++ b/framework/entity/SecurityEntities.xml
@@ -20,7 +20,6 @@ along with this software (see the LICENSE.md file). If not, see
     <!-- ========================================================= -->
 
     <!-- ========== Artifact Group ========== -->
-
     <entity entity-name="ArtifactGroup" package="moqui.security" use="configuration" short-alias="artifactGroups">
         <field name="artifactGroupId" type="id" is-pk="true"/>
         <field name="description" type="text-medium"/>
@@ -43,7 +42,7 @@ along with this software (see the LICENSE.md file). If not, see
                 in other words permission to access an artifact implies permission to access everything needed to get
                 to that artifact.
 
-                Defaults to Y. 
+                Defaults to Y.
             </description>
         </field>
         <field name="filterMap" type="text-long"><description>A Groovy expression that evaluates to a Map that
@@ -308,12 +307,35 @@ along with this software (see the LICENSE.md file). If not, see
         <alias name="receiveNotifications" entity-alias="NTU"/>
         <alias name="emailNotifications" entity-alias="NTU"/>
     </view-entity>
-
+    <entity entity-name="UserAuthcFactor" package="moqui.security" use="configuration">
+        <description>This entity is for recording User Authentication Factors.</description>
+        <field name="factorId" type="id" is-pk="true"/>
+        <field name="userId" type="id" not-null="true"/>
+        <field name="fromFactorId" type="id"/>
+        <field name="factorTypeEnumId" type="id"/>
+        <field name="fromDate" type="date-time"/>
+        <field name="thruDate" type="date-time"/>
+        <field name="factorOption" type="text-medium" encrypt="true">
+            <description>Use varies based on factor type: TOTP is shared secret, Single Use is the code, Email Code is email address</description></field>
+        <field name="needsValidation" type="text-indicator"/>
+        <relationship type="one-nofk" related="moqui.security.UserAccount" short-alias="user">
+            <description>No FK in order to allow externally authenticated users.</description></relationship>
+        <relationship type="one" title="UserAuthcFactorType" related="moqui.basic.Enumeration" short-alias="factorTypeEnum">
+            <key-map field-name="factorTypeEnumId"/></relationship>
+        <seed-data>
+            <moqui.basic.EnumerationType description="User Authentication Factor Type" enumTypeId="UserAuthcFactorType"/>
+            <moqui.basic.Enumeration description="Authenticator App (TOTP)" enumId="UafTotp" enumTypeId="UserAuthcFactorType"/>
+            <moqui.basic.Enumeration description="Single Use Code" enumId="UafSingleUse" enumTypeId="UserAuthcFactorType"/>
+            <moqui.basic.Enumeration description="Email Code (OTP)" enumId="UafEmail" enumTypeId="UserAuthcFactorType"/>
+            <!--            <moqui.basic.Enumeration description="HMAC-based one-time password" enumId="UafHotp" enumTypeId="UserAuthcFactorType"/>-->
+        </seed-data>
+    </entity>
     <entity entity-name="UserGroup" package="moqui.security" use="configuration" short-alias="userGroups">
         <field name="userGroupId" type="id" is-pk="true"/>
         <field name="description" type="text-medium"/>
         <field name="groupTypeEnumId" type="id"/>
         <field name="ipAllowed" type="text-medium"><description>See UserAccout.ipAllowed</description></field>
+        <field name="requireAuthcFactor" type="text-indicator"/>
         <relationship type="one" title="UserGroupType" related="moqui.basic.Enumeration" short-alias="groupTypeEnum">
             <key-map field-name="groupTypeEnumId"/></relationship>
         <relationship type="many" related="moqui.security.UserGroupPermission" short-alias="permissions">

--- a/framework/service/org/moqui/impl/UserServices.xml
+++ b/framework/service/org/moqui/impl/UserServices.xml
@@ -21,7 +21,7 @@ along with this software (see the LICENSE.md file). If not, see
         </in-parameters>
         <actions><script>ec.user.setPreference(preferenceKey, preferenceValue)</script></actions>
     </service>
-    
+
     <service verb="create" noun="UserAccount" authenticate="anonymous-all" allow-remote="false">
         <in-parameters>
             <auto-parameters entity-name="moqui.security.UserAccount" include="nonpk"><exclude field-name="currentPassword"/>
@@ -351,6 +351,288 @@ along with this software (see the LICENSE.md file). If not, see
                 <return error="true" message="Can only create initial admin account if there are no UserAccount records"/></if>
             <service-call name="org.moqui.impl.UserServices.create#UserAccount" in-map="context" out-map="context"/>
             <service-call name="create#moqui.security.UserGroupMember" in-map="[userId:userId, userGroupId:'ADMIN']"/>
+        </actions>
+    </service>
+
+    <!-- ================================================= -->
+    <!-- ====== User Authentication Factor Services ====== -->
+    <!-- ================================================= -->
+
+    <!-- TODO: Limit the amount of attempts to validate authc code. Similair to Tarpit Locks (I think). -->
+    <service verb="validate" noun="UserAuthcFactorCode">
+        <description>Determine whether a user inputted code is valid based on the current UserAuthcFactor entries for that user.</description>
+        <in-parameters>
+            <parameter name="userId" required="true"/>
+            <parameter name="code"/>
+        </in-parameters>
+        <out-parameters>
+            <parameter name="verified" type="Boolean"/>
+            <parameter name="factorId"/>
+        </out-parameters>
+        <actions>
+            <set field="verified" from="false"/>
+
+            <!-- This is the setup script for verifying TOTP codes with the samstevens library. -->
+            <script>
+                import dev.samstevens.totp.time.*
+                import dev.samstevens.totp.code.*
+                TimeProvider timeProvider = new SystemTimeProvider()
+                CodeGenerator codeGenerator = new DefaultCodeGenerator()
+                CodeVerifier verifier = new DefaultCodeVerifier(codeGenerator, timeProvider)
+            </script>
+
+            <entity-find entity-name="moqui.security.UserAuthcFactor" list="userAuthcFactorList">
+                <date-filter/>
+                <econdition field-name="userId"/>
+                <econdition field-name="factorTypeEnumId" operator="not-equals" value="UafEmail"/>
+            </entity-find>
+
+            <iterate list="userAuthcFactorList" entry="userAuthcFactor">
+                <if condition="userAuthcFactor.factorTypeEnumId == 'UafSingleUse'">
+                    <then>
+                        <!-- This checks to see whether the hashed single use code in the database is the input code hashed. -->
+                        <if condition="userAuthcFactor.factorOption == ec.ecfi.getSimpleHash(code, 'SaltySalt')">
+                            <set field="factorId" from="userAuthcFactor.factorId"/>
+                            <set field="verified" from="true"/>
+                            <service-call name="update#moqui.security.UserAuthcFactor" in-map="[factorId:userAuthcFactor.factorId,thruDate:ec.user.nowTimestamp]"/>
+                            <if condition="userAuthcFactor.fromFactorId"><service-call name="update#moqui.security.UserAuthcFactor" in-map="[factorId:userAuthcFactor.fromFactorId,needsValidation:'N']"/></if>
+                        </if>
+                    </then>
+                    <else-if condition="userAuthcFactor.factorTypeEnumId == 'UafTotp'">
+                        <!-- This checks to see whether the secret key stored in the database matches the input code at this time -->
+                        <if condition="verifier.isValidCode(userAuthcFactor.factorOption, code)">
+                            <set field="factorId" from="userAuthcFactor.factorId"/>
+                            <set field="verified" from="true"/>
+                            <service-call name="update#moqui.security.UserAuthcFactor" in-map="[factorId:userAuthcFactor.factorId,needsValidation:'N']"/>
+                        </if>
+                    </else-if>
+                </if>
+            </iterate>
+        </actions>
+    </service>
+
+    <service verb="create" noun="SingleUseAuthcCodes">
+        <description>Create multiple single use authentication factors.</description>
+        <in-parameters>
+            <parameter name="userId" required="true"/>
+            <parameter name="fromFactorId" default=""/>
+            <parameter name="thruDate" type="Timestamp" default="ec.user.nowTimestamp + 365"/>
+            <parameter name="numberOfCodes" type="Integer" default="6"/>
+        </in-parameters>
+        <out-parameters><parameter name="singleUseCodes" type="List"/></out-parameters>
+        <actions>
+            <if condition="numberOfCodes &gt; 21"><return error="true" message="Cannot create more than 21 codes at a time"/></if>
+            <set field="factorTypeEnumId" value="UafSingleUse"/>
+            <set field="fromDate" from="ec.user.nowTimestamp"/>
+            <entity-find entity-name="moqui.security.UserAuthcFactor" list="userAuthcFactorList">
+                <date-filter/>
+                <econdition field-name="userId"/>
+                <econdition field-name="fromFactorId"/>
+                <econdition field-name="factorTypeEnumId" value="UafSingleUse"/>
+            </entity-find>
+
+            <!-- This automatically invalidates any current single use authentication codes that are from the fromFactorId -->
+            <iterate list="userAuthcFactorList" entry="userAuthcFactor"><service-call name="update#moqui.security.UserAuthcFactor" in-map="[factorId:userAuthcFactor.factorId, thruDate:ec.user.nowTimestamp]"/></iterate>
+            <set field="singleUseCodes" from="[]"/>
+
+            <!-- This generates the actual codes using java's SecureRandom library (currently 8 integer digits) -->
+            <script>for (int i = 0; i &lt; numberOfCodes; i++) singleUseCodes.add(new java.security.SecureRandom().nextInt(99999999).toString().padLeft(8,'0'))</script>
+            <iterate list="singleUseCodes" entry="code">
+                <set field="factorOption" from="ec.ecfi.getSimpleHash(code, 'SaltySalt')"/>
+                <service-call name="create#moqui.security.UserAuthcFactor" in-map="context"/>
+            </iterate>
+        </actions>
+    </service>
+    <service verb="create" noun="SingleUseAuthcFactor">
+        <description>Create a single use authentication factor.</description>
+        <in-parameters>
+            <parameter name="userId" required="true"></parameter>
+            <parameter name="fromFactorId" default=""/>
+            <parameter name="thruDate" type="Timestamp" default="ec.user.nowTimestamp + 1"/>
+        </in-parameters>
+        <out-parameters>
+            <parameter name="factorId"/>
+            <parameter name="code"/>
+            <parameter name="thruDate"/>
+        </out-parameters>
+        <actions>
+            <!-- If there is a fromFactorId, this automatically invalidates any current single use authentication codes that are from the fromFactorId -->
+            <if condition="fromFactorId">
+                <entity-find entity-name="moqui.security.UserAuthcFactor" list="userAuthcFactorList">
+                    <date-filter/><econdition field-name="userId"/><econdition field-name="fromFactorId"/>
+                    <econdition field-name="factorTypeEnumId" value="UafSingleUse"/></entity-find>
+                <iterate list="userAuthcFactorList" entry="userAuthcFactor">
+                    <service-call name="update#moqui.security.UserAuthcFactor" in-map="[factorId:userAuthcFactor.factorId, thruDate:ec.user.nowTimestamp]"/>
+                </iterate>
+            </if>
+
+            <set field="factorTypeEnumId" value="UafSingleUse"/>
+            <set field="fromDate" from="ec.user.nowTimestamp"/>
+            <set field="code" from="new java.security.SecureRandom().nextInt(999999).toString().padLeft(6,'0')"/>
+            <set field="factorOption" from="ec.ecfi.getSimpleHash(code, 'SaltySalt')"/>
+            <service-call name="create#moqui.security.UserAuthcFactor" in-map="context" out-map="context"/>
+        </actions>
+    </service>
+    <service verb="send" noun="AuthcCodeEmail" authenticate="anonymous-view">
+        <description>Service to send an email with a single use code in it for verifying an email.</description>
+        <in-parameters><parameter name="emailFactorId" required="true"/></in-parameters>
+        <out-parameters>
+            <parameter name="singleUseFactorId"/>
+            <parameter name="code"/>
+        </out-parameters>
+        <actions>
+            <entity-find-one entity-name="moqui.security.UserAuthcFactor" value-field="userAuthcFactor">
+                <field-map field-name="factorId" from="emailFactorId"/></entity-find-one>
+
+            <!-- create a new single use authc factor code and get it's factorId -->
+            <service-call name="org.moqui.impl.UserServices.create#SingleUseAuthcFactor" in-map="[userId:userAuthcFactor.userId,fromFactorId:emailFactorId]" out-map="context"/>
+            <set field="singleUseFactorId" from="factorId"/>
+
+            <!-- send an email with the single use code -->
+            <service-call name="org.moqui.impl.EmailServices.send#EmailTemplate" async="true">
+                <field-map field-name="emailTemplateId" value="SINGLE_USE_CODE"/>
+                <field-map field-name="toAddresses" from="userAuthcFactor.factorOption"/>
+                <field-map field-name="bodyParameters" from="[code:code,thruDateString:thruDate.toString()]"/>
+            </service-call>
+            <message>Authentication code sent to ${userAuthcFactor.factorOption}</message>
+
+            <!-- if the email just sent to is not the main email address for the user send the main email address a notification email that an email with a code was sent -->
+            <entity-find-one entity-name="moqui.security.UserAccount" value-field="userAccount">
+                <field-map field-name="userId" from="userAuthcFactor.userId"/></entity-find-one>
+            <if condition="userAccount.emailAddress &amp;&amp; userAccount.emailAddress != userAuthcFactor.factorOption">
+                <service-call name="org.moqui.impl.EmailServices.send#EmailTemplate" async="true">
+                    <field-map field-name="emailTemplateId" value="ADDED_EMAIL_AUTHC_FACTOR"/>
+                    <field-map field-name="toAddresses" from="userAccount.emailAddress"/>
+                    <field-map field-name="bodyParameters" from="[userEmail:userAuthcFactor.factorOption,thruDateString:thruDate.toString()]"/>
+                </service-call>
+            </if>
+        </actions>
+    </service>
+    <service verb="create" noun="EmailUserAuthcFactor">
+        <description>Creates a UserAuthcFactor entry for email, and an entry for the single use code to verify the email.</description>
+        <in-parameters>
+            <parameter name="userId" required="true"><description>User to enable Email Factor Method</description></parameter>
+            <parameter name="thruDate" type="Timestamp" default="ec.user.nowTimestamp+365"/>
+            <parameter name="factorOption" required="true"><text-email/></parameter>
+        </in-parameters>
+        <out-parameters>
+            <parameter name="factorId"/>
+            <parameter name="singleUseFactorId"/>
+            <parameter name="code"/>
+        </out-parameters>
+        <actions>
+            <set field="factorTypeEnumId" value="UafEmail"/>
+            <set field="fromDate" from="ec.user.nowTimestamp"/>
+            <set field="needsValidation" value="Y"/>
+
+            <entity-find-count entity-name="moqui.security.UserAuthcFactor" count-field="userAuthcFactorCount">
+                <date-filter/>
+                <econdition field-name="userId"/>
+                <econdition field-name="factorTypeEnumId"/>
+                <econdition field-name="factorOption"/>
+            </entity-find-count>
+
+            <if condition="userAuthcFactorCount == 0">
+                <then>
+                    <!-- If there are no UserAuthcFactor entries for this user with the same email, create the UserAuthcFactor. -->
+                    <service-call name="create#moqui.security.UserAuthcFactor" in-map="context" out-map="context"/>
+                    <!-- don't send code email on create, do it manually if needed from UI:
+                    <service-call name="org.moqui.impl.UserServices.send#AuthcCodeEmail" in-map="emailFactorId:factorId" out-map="context"/>
+                    -->
+                </then>
+                <else-if condition="userAuthcFactorCount == 1">
+                    <!-- There is an UserAuthcFactor for this user that has the same email. Send error message to the user.-->
+                    <return error="true" message="Email entry already exists for: ${factorOption}. Cannot create duplicate email."/>
+                </else-if>
+            </if>
+        </actions>
+    </service>
+
+    <service verb="create" noun="UserAuthcFactorTotp">
+        <description>Create an Authenticator App Factor.</description>
+        <in-parameters>
+            <parameter name="userId" required="true"/>
+            <parameter name="thruDate" type="Timestamp" default="ec.user.nowTimestamp + 365"/>
+            <parameter name="needsValidation" default-value="Y"/>
+        </in-parameters>
+        <out-parameters>
+            <parameter name="factorId"/>
+            <parameter name="factorOption"/>
+        </out-parameters>
+        <actions>
+            <script>
+                import dev.samstevens.totp.secret.DefaultSecretGenerator
+                DefaultSecretGenerator gen = new DefaultSecretGenerator()
+            </script>
+            <set field="factorTypeEnumId" value="UafTotp"/>
+            <set field="fromDate" from="ec.user.nowTimestamp"/>
+            <set field="factorOption" from="gen.generate()"/>
+            <service-call name="create#moqui.security.UserAuthcFactor" in-map="context" out-map="context"/>
+        </actions>
+    </service>
+    <service verb="setup" noun="UserAuthcFactorTotp">
+        <in-parameters>
+            <parameter name="factorId"/>
+            <parameter name="userId" required="true"/>
+            <parameter name="thruDate"/>
+        </in-parameters>
+        <out-parameters>
+            <parameter name="qrLabel"/>
+            <parameter name="qrIssuer"/>
+            <parameter name="qrSecret"/>
+            <parameter name="qrUri"/>
+            <parameter name="dataUri"/>
+            <parameter name="needsValidation"/>
+        </out-parameters>
+        <actions>
+            <entity-find-one entity-name="moqui.security.UserAccount" value-field="userAccount">
+                <field-map field-name="userId" from="userId"/></entity-find-one>
+
+            <if condition="!factorId">
+                <then>
+                    <!-- If this service is called and no factorId is specified it will create a Totp UserAuthcFactor entry -->
+                    <service-call name="org.moqui.impl.UserServices.create#UserAuthcFactorTotp"
+                                  in-map="[userId:userId, thruDate:thruDate]" out-map="userFactor"/>
+                </then><else>
+                    <!-- If this service is called and a factorId is specified, get the userFactor from the database -->
+                    <entity-find-one entity-name="moqui.security.UserAuthcFactor" value-field="userFactor">
+                        <field-map field-name="factorId"/>
+                        <field-map field-name="userId"/>
+                    </entity-find-one>
+                </else>
+            </if>
+            <set field="factorOption" from="userFactor.factorOption"/>
+
+            <script>
+                import dev.samstevens.totp.qr.*
+                import dev.samstevens.totp.code.HashingAlgorithm
+                import dev.samstevens.totp.util.Utils
+                QrData data = new QrData.Builder().label(userAccount.username).secret(factorOption).issuer(ec.web.getHostName(false))
+                    .algorithm(HashingAlgorithm.SHA1).digits(6).period(30).build()
+                QrGenerator generator = new ZxingPngQrGenerator()
+            </script>
+            <set field="qrLabel" from="data.label"/><set field="qrIssuer" from="data.issuer"/><set field="qrSecret" from="data.secret"/>
+            <set field="dataUri" from="Utils.getDataUriForImage(generator.generate(data), generator.getImageMimeType())"/>
+            <set field="needsValidation" from="userFactor.needsValidation"/>
+        </actions>
+    </service>
+
+    <service verb="invalidate" noun="UserAuthcFactorEntry">
+        <description>Invalidate a factorId and any UserAuthcFactor entries that are dependant on that factorId.</description>
+        <in-parameters>
+            <parameter name="factorId" required="true"/>
+            <parameter name="userId" required="true"/>
+            <parameter name="fromFactorId"/>
+        </in-parameters>
+        <actions>
+            <entity-find entity-name="moqui.security.UserAuthcFactor" list="userAuthcFactorList">
+                <date-filter/><econdition field-name="userId"/></entity-find>
+
+            <iterate list="userAuthcFactorList" entry="userAuthcFactor">
+                <if condition="userAuthcFactor.fromFactorId == factorId || userAuthcFactor.factorId == factorId">
+                    <service-call name="update#moqui.security.UserAuthcFactor" in-map="[factorId:userAuthcFactor.factorId, thruDate:ec.user.nowTimestamp]"/>
+                </if>
+            </iterate>
         </actions>
     </service>
 </services>

--- a/framework/src/main/groovy/org/moqui/impl/screen/ScreenRenderImpl.groovy
+++ b/framework/src/main/groovy/org/moqui/impl/screen/ScreenRenderImpl.groovy
@@ -1,12 +1,12 @@
 /*
  * This software is in the public domain under CC0 1.0 Universal plus a
  * Grant of Patent License.
- * 
+ *
  * To the extent possible under law, the author(s) have dedicated all
  * copyright and related and neighboring rights to this software to the
  * public domain worldwide. This software is distributed without any
  * warranty.
- * 
+ *
  * You should have received a copy of the CC0 Public Domain Dedication
  * along with this software (see the LICENSE.md file). If not, see
  * <http://creativecommons.org/publicdomain/zero/1.0/>.

--- a/framework/xsd/xml-screen-2.1.xsd
+++ b/framework/xsd/xml-screen-2.1.xsd
@@ -600,7 +600,7 @@ along with this software (see the LICENSE.md file). If not, see
         <xs:attribute name="style" type="xs:string"/>
         <xs:attribute name="type" default="div"><xs:simpleType><xs:restriction base="xs:token">
             <xs:enumeration value="div"/><xs:enumeration value="span"/>
-            <xs:enumeration value="ul"/><xs:enumeration value="li"/>
+            <xs:enumeration value="ul"/><xs:enumeration value="ol"/><xs:enumeration value="li"/>
             <xs:enumeration value="dl"/><xs:enumeration value="dd"/>
             <xs:enumeration value="header"/><xs:enumeration value="footer"/>
             <xs:enumeration value="code"/><xs:enumeration value="pre"/>

--- a/moqui-util/build.gradle
+++ b/moqui-util/build.gradle
@@ -65,6 +65,7 @@ dependencies {
     // javax.activation - required for Java 11
     compile 'com.sun.activation:javax.activation:1.2.0' // CDDL 1.1
     // Apache Commons
+    compile 'commons-codec:commons-codec:1.15'
     compile 'commons-fileupload:commons-fileupload:1.4' // Apache 2.0
 }
 

--- a/moqui-util/src/main/java/org/moqui/util/StringUtilities.java
+++ b/moqui-util/src/main/java/org/moqui/util/StringUtilities.java
@@ -13,6 +13,7 @@
  */
 package org.moqui.util;
 
+import org.apache.commons.codec.binary.*;
 import org.codehaus.groovy.runtime.DefaultGroovyMethods;
 import org.moqui.BaseException;
 import org.slf4j.Logger;
@@ -431,10 +432,14 @@ public class StringUtilities {
     }
 
     public static String getRandomString(int length) {
+        return getRandomString(length, null);
+    }
+    public static String getRandomString(int length, BaseNCodec baseNCodec) {
+        if (baseNCodec == null) baseNCodec = new org.apache.commons.codec.binary.Base64(true);
         SecureRandom sr = new SecureRandom();
         byte[] randomBytes = new byte[length];
         sr.nextBytes(randomBytes);
-        String randomStr = Base64.getUrlEncoder().encodeToString(randomBytes);
+        String randomStr = baseNCodec.encodeToString(randomBytes);
         if (randomStr.length() > length) randomStr = randomStr.substring(0, length);
         return randomStr;
     }


### PR DESCRIPTION
The pull request makes changes to moqui-framework, moqui-runtime, and SimpleScreens.

The biggest things to check are:

    In my development environment, I was occasionally getting 28 second loading screens when calling services in UserServices.xml to create a UserAuthcFactor. Make sure that in other environments this doesn't happen.
    Ensure that the forms don't allow the user to specify their userId so that permissions for users are enforced.

In moqui-framework:

    a dependency is added to a build.gradle file: dev.samstevens.totp:totp:1.7.1
    Email templates, configuration, and files are added for:
        Sending single use codes
        Adding the email authc type
        Notifying the main email address about a new email authc type
    The UserAuthcFactor entity in UserServices.xml
    A minor change to UserGroup entity where the UserGroup can require the users to have a UserAuthcFactor
    Changes to the login process required for having a secondary authentication
    Other necessary minor misc changes to the code
