### PR TITLE
fix: use time-date@format for javaFormat when preparing data for form

### DIFF
--- a/framework/src/main/groovy/org/moqui/impl/screen/ScreenRenderImpl.groovy
+++ b/framework/src/main/groovy/org/moqui/impl/screen/ScreenRenderImpl.groovy
@@ -1848,7 +1848,9 @@ class ScreenRenderImpl implements ScreenRender {
                 fieldValues.put(fieldName + "_thru", ec.contextStack.getByString(fieldName + "_thru"))
             } else if ("date-time".equals(widgetName)) {
                 String type = widgetNode.attribute("type")
-                String javaFormat = "date".equals(type) ? "yyyy-MM-dd" : ("time".equals(type) ? "HH:mm" : "yyyy-MM-dd HH:mm")
+                String javaFormat = widgetNode.attribute("format")
+                if (javaFormat == null)
+                    javaFormat = "date".equals(type) ? "yyyy-MM-dd" : ("time".equals(type) ? "HH:mm" : "yyyy-MM-dd HH:mm")
                 fieldValues.put(fieldName, getFieldValueString(fieldNode, widgetNode.attribute("default-value"), javaFormat))
             } else if ("display-entity".equals(widgetName)) {
                 // primary value is for hidden field only, otherwise add nothing (display only)


### PR DESCRIPTION
fixes issue when using non-default date-time format in qvt rendering mode. A date like 2022/04/19 would have been displayed as 20/22/0419 when using format="MM/dd/yyyy"