### PR TITLE
On grgit clone, checkout the branch specified in an addons.xml file

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -980,6 +980,7 @@ File getComponent(String compName, String type, Node addons, Node myaddons, Set 
 }
 File downloadComponent(String targetDirPath, String type, Node component, Node addons, Node myaddons) {
     String compName = component.'@name'
+    String branch = component.'@branch'
 
     String repositoryName = (component.'@repository' ?: myaddons?.'@default-repository' ?: addons.'@default-repository' ?: 'github')
     Node repository = myaddons != null ? (Node) myaddons.repository.find({ it."@name" == repositoryName }) : null
@@ -989,7 +990,7 @@ File downloadComponent(String targetDirPath, String type, Node component, Node a
     if (location == null) throw new InvalidUserDataException("Location for type ${type} now found in repository ${repositoryName}")
 
     String url = Eval.me('component', component, '"""' + location.'@url' + '"""')
-    logger.lifecycle("Getting ${compName} (type ${type}) from ${url} to ${targetDirPath}")
+    logger.lifecycle("Getting ${compName} (type ${type}) from ${url} at ${branch} to ${targetDirPath}")
 
     File targetDir = file(targetDirPath)
     if (targetDir.exists()) { logger.lifecycle("Component ${compName} already exists at ${targetDir}"); return targetDir }
@@ -1005,7 +1006,7 @@ File downloadComponent(String targetDirPath, String type, Node component, Node a
         // logger.lifecycle("Deleting dir ${targetDirPath}/${archiveDirName}")
         delete file("${targetDirPath}/${archiveDirName}")
     } else if (type == 'git') {
-        Grgit.clone(dir: targetDir, uri: url)
+        Grgit.clone(dir: targetDir, uri: url, refToCheckout: branch)
     }
     logger.lifecycle("Downloaded ${compName} to ${targetDirPath}")
     return targetDir


### PR DESCRIPTION
Expected behavior:

When cloning a repo with a branch specified in an `addons.xml` file, checkout that branch rather than the default HEAD branch. 

This does the behavior stated above by passing a parameter to checkout the specified branch.

Testing / Edge Cases:
- When no branch is passed, it defaults to checking out the HEAD branch.
- If the branch specified doesn't exist then an empty repository is created instead of defaulting to the HEAD branch.

Functionality changes:
If a branch is specified that doesn't exist before this, it would just default to the HEAD branch. However, after it will result in an empty directory

Note:
We're currently running java 11 and gradle v7.4.2 and [according to the release](https://github.com/ajoberstar/grgit/releases/tag/2.2.1) it doesn't support java 11 or gradle v7.4.2. We should probably upgrade to [grgit 4.1.1](https://plugins.gradle.org/plugin/org.ajoberstar.grgit/4.1.1) or [5.0.0](https://github.com/ajoberstar/grgit/releases/tag/5.0.0). What do you think?
