### PR TITLE
Anonymous usage of screens with transitions

### DIFF
--- a/framework/src/main/groovy/org/moqui/impl/screen/ScreenUrlInfo.groovy
+++ b/framework/src/main/groovy/org/moqui/impl/screen/ScreenUrlInfo.groovy
@@ -271,7 +271,9 @@ class ScreenUrlInfo {
         ArrayDeque<ArtifactExecutionInfoImpl> artifactExecutionInfoStack = new ArrayDeque<ArtifactExecutionInfoImpl>()
 
         int screenPathDefListSize = screenPathDefList.size()
-        boolean allowedByScreenRequireAuthenticationAttribute = false
+        boolean allowedByScreenDefinitionView = false
+        boolean allowedByScreenDefinitionAll = false
+        boolean allowedByScreenDefinition = false
         for (int i = 0; i < screenPathDefListSize; i++) {
             AuthzAction curActionEnum = (i == (screenPathDefListSize - 1)) ? actionEnum : ArtifactExecutionInfo.AUTHZA_VIEW
             ScreenDefinition screenDef = (ScreenDefinition) screenPathDefList.get(i)
@@ -287,9 +289,11 @@ class ScreenUrlInfo {
 
             String requireAuthentication = screenNode.attribute('require-authentication')
             if (actionEnum == ArtifactExecutionInfo.AUTHZA_VIEW) {
-                allowedByScreenRequireAuthenticationAttribute = allowedByScreenRequireAuthenticationAttribute || "anonymous-view".equals(requireAuthentication) || "anonymous-all".equals(requireAuthentication)
+                allowedByScreenDefinitionView = true
+                allowedByScreenDefinition = allowedByScreenDefinition || "anonymous-view".equals(requireAuthentication) || "anonymous-all".equals(requireAuthentication)
             } else if (actionEnum == ArtifactExecutionInfo.AUTHZA_ALL)
-                allowedByScreenRequireAuthenticationAttribute = allowedByScreenRequireAuthenticationAttribute || "anonymous-all".equals(requireAuthentication)
+                allowedByScreenDefinitionAll = true
+                allowedByScreenDefinition = allowedByScreenDefinition || "anonymous-all".equals(requireAuthentication)
             if (!aefi.isPermitted(aeii, lastAeii,
                     isLast ? (!requireAuthentication || "true".equals(requireAuthentication)) : false, false, false, artifactExecutionInfoStack)) {
                 //logger.warn("TOREMOVE user ${userId} is NOT allowed to view screen at path ${this.fullPathNameList} because of screen at ${screenDef.location}")
@@ -301,7 +305,7 @@ class ScreenUrlInfo {
         }
 
         // see if the transition is permitted
-        if (!allowedByScreenRequireAuthenticationAttribute && transitionItem != null) {
+        if (!allowedByScreenDefinition && transitionItem != null) {
             ScreenDefinition lastScreenDef = (ScreenDefinition) screenPathDefList.get(screenPathDefList.size() - 1)
             ArtifactExecutionInfoImpl aeii = new ArtifactExecutionInfoImpl("${lastScreenDef.location}/${transitionItem.name}",
                     ArtifactExecutionInfo.AT_XML_SCREEN_TRANS, ArtifactExecutionInfo.AUTHZA_VIEW, null)
@@ -324,9 +328,9 @@ class ScreenUrlInfo {
 
             boolean allowedByServiceDefinition = false
             if (authzAction == ArtifactExecutionInfo.AUTHZA_VIEW) {
-                allowedByServiceDefinition = "anonymous-view".equals(sd.authenticate) || "anonymous-all".equals(sd.authenticate)
+                allowedByServiceDefinition = allowedByScreenDefinitionView || "anonymous-view".equals(sd.authenticate) || "anonymous-all".equals(sd.authenticate)
             } else if (authzAction == ArtifactExecutionInfo.AUTHZA_ALL)
-                allowedByServiceDefinition = "anonymous-all".equals(sd.authenticate)
+                allowedByServiceDefinition = allowedByScreenDefinitionAll || "anonymous-all".equals(sd.authenticate)
             ArtifactExecutionInfoImpl aeii = new ArtifactExecutionInfoImpl(serviceName, ArtifactExecutionInfo.AT_SERVICE, authzAction, null)
 
             ArtifactExecutionInfoImpl lastAeii = (ArtifactExecutionInfoImpl) artifactExecutionInfoStack.peekFirst()

--- a/framework/src/main/groovy/org/moqui/impl/screen/ScreenUrlInfo.groovy
+++ b/framework/src/main/groovy/org/moqui/impl/screen/ScreenUrlInfo.groovy
@@ -322,10 +322,15 @@ class ScreenUrlInfo {
             if (authzAction == null) authzAction = ServiceDefinition.verbAuthzActionEnumMap.get(ServiceDefinition.getVerbFromName(serviceName))
             if (authzAction == null) authzAction = ArtifactExecutionInfo.AUTHZA_ALL
 
+            boolean allowedByServiceDefinition = false
+            if (authzAction == ArtifactExecutionInfo.AUTHZA_VIEW) {
+                allowedByServiceDefinition = "anonymous-view".equals(sd.authenticate) || "anonymous-all".equals(sd.authenticate)
+            } else if (authzAction == ArtifactExecutionInfo.AUTHZA_ALL)
+                allowedByServiceDefinition = "anonymous-all".equals(sd.authenticate)
             ArtifactExecutionInfoImpl aeii = new ArtifactExecutionInfoImpl(serviceName, ArtifactExecutionInfo.AT_SERVICE, authzAction, null)
 
             ArtifactExecutionInfoImpl lastAeii = (ArtifactExecutionInfoImpl) artifactExecutionInfoStack.peekFirst()
-            if (!aefi.isPermitted(aeii, lastAeii, true, false, false, null)) {
+            if (!aefi.isPermitted(aeii, lastAeii, !allowedByServiceDefinition, false, false, null)) {
                 // logger.warn("TOREMOVE user ${username} is NOT allowed to run transition at path ${this.fullPathNameList} because of screen at ${screenDef.location}")
                 if (permittedCacheKey != null) aefi.screenPermittedCache.put(permittedCacheKey, false)
                 return false

--- a/framework/src/main/groovy/org/moqui/impl/screen/ScreenUrlInfo.groovy
+++ b/framework/src/main/groovy/org/moqui/impl/screen/ScreenUrlInfo.groovy
@@ -288,12 +288,12 @@ class ScreenUrlInfo {
             MNode screenNode = screenDef.getScreenNode()
 
             String requireAuthentication = screenNode.attribute('require-authentication')
+            allowedByScreenDefinitionView = "anonymous-view".equals(requireAuthentication)
+            allowedByScreenDefinitionAll = "anonymous-all".equals(requireAuthentication)
             if (actionEnum == ArtifactExecutionInfo.AUTHZA_VIEW) {
-                allowedByScreenDefinitionView = true
-                allowedByScreenDefinition = allowedByScreenDefinition || "anonymous-view".equals(requireAuthentication) || "anonymous-all".equals(requireAuthentication)
+                allowedByScreenDefinition = allowedByScreenDefinition || allowedByScreenDefinitionView || allowedByScreenDefinitionAll
             } else if (actionEnum == ArtifactExecutionInfo.AUTHZA_ALL)
-                allowedByScreenDefinitionAll = true
-                allowedByScreenDefinition = allowedByScreenDefinition || "anonymous-all".equals(requireAuthentication)
+                allowedByScreenDefinition = allowedByScreenDefinition || allowedByScreenDefinitionAll
             if (!aefi.isPermitted(aeii, lastAeii,
                     isLast ? (!requireAuthentication || "true".equals(requireAuthentication)) : false, false, false, artifactExecutionInfoStack)) {
                 //logger.warn("TOREMOVE user ${userId} is NOT allowed to view screen at path ${this.fullPathNameList} because of screen at ${screenDef.location}")
@@ -329,7 +329,7 @@ class ScreenUrlInfo {
             boolean allowedByServiceDefinition = false
             if (authzAction == ArtifactExecutionInfo.AUTHZA_VIEW) {
                 allowedByServiceDefinition = allowedByScreenDefinitionView || "anonymous-view".equals(sd.authenticate) || "anonymous-all".equals(sd.authenticate)
-            } else if (authzAction == ArtifactExecutionInfo.AUTHZA_ALL)
+            } else if (authzAction in [ArtifactExecutionInfo.AUTHZA_ALL, ArtifactExecutionInfo.AUTHZA_CREATE, ArtifactExecutionInfo.AUTHZA_UPDATE, ArtifactExecutionInfo.AUTHZA_DELETE])
                 allowedByServiceDefinition = allowedByScreenDefinitionAll || "anonymous-all".equals(sd.authenticate)
             ArtifactExecutionInfoImpl aeii = new ArtifactExecutionInfoImpl(serviceName, ArtifactExecutionInfo.AT_SERVICE, authzAction, null)
 


### PR DESCRIPTION
A transition defined in a screen with screen.@require-authentication = "anonymous-view" or "anonymous-all" will be considered as not permitted, thus disabling links and forms that attempt to link to that transition.

However, when accessing the same transition directly using plain links, the transition gets executed as expected.

This change avoids the extra check for transitions when the corresponding require-authentication attribute is present, and keeps the check on the service when the transition has a single service call, but honoring the "authenticate" attribute of the service definition considering the authorization level being "view" or "all" according to the screen definition
[updated to reflect changes in last commit for extra service check when transition is single service call.]