### PR TITLE
Remove myaddons.xml from .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,3 @@
-# separate addons file to add/override components
-myaddons.xml
-
 # gradle/build files
 build
 .gradle


### PR DESCRIPTION
When making a fork, the first thing that someone should do is add a `myaddons.xml` file so that they can use gradle for getting their forked git repos. Having a `.gitignore` makes sense for the main branch, but for forked repos (which is the expected way to use moqui) it doesn't make sense. 

Feel free to explain why this argument doesn't makes sense, but this is just a quality of life thing that I think will help make Moqui better.