### PR TITLE
Form list map

### DIFF
--- a/framework/src/main/groovy/org/moqui/impl/entity/AggregationUtil.java
+++ b/framework/src/main/groovy/org/moqui/impl/entity/AggregationUtil.java
@@ -101,6 +101,15 @@ public class AggregationUtil {
                     originalCount++;
                 }
             }
+        } else if (listObj instanceof Map) {
+            Iterator listIter = (Iterator) ((Map<?, ?>) listObj).entrySet().iterator();
+            int i = 0;
+            while (listIter.hasNext()) {
+                Object curObject = listIter.next();
+                processAggregateOriginal(curObject, resultList, includeFields, groupRows, totalsMap, i, listIter.hasNext(), makeSubList, eci);
+                i++;
+                originalCount++;
+            }
         } else if (listObj instanceof Iterator) {
             Iterator listIter = (Iterator) listObj;
             int i = 0;


### PR DESCRIPTION
Allow a `form-list`'s `list` element to iterate over a map's entries as an entrySet iterator. 