### PR TITLE
Update to session token condition

### DIFF
--- a/framework/src/main/groovy/org/moqui/impl/screen/ScreenRenderImpl.groovy
+++ b/framework/src/main/groovy/org/moqui/impl/screen/ScreenRenderImpl.groovy
@@ -425,7 +425,6 @@ class ScreenRenderImpl implements ScreenRender {
                 // require a moquiSessionToken parameter for all but get
                 if (request.getMethod().toLowerCase() != "get" && webappInfo != null && webappInfo.requireSessionToken &&
                         targetTransition.getRequireSessionToken() &&
-                        !"true".equals(request.getAttribute("moqui.session.token.created")) &&
                         !"true".equals(request.getAttribute("moqui.request.authenticated"))) {
                     String passedToken = (String) ec.web.getParameters().get("moquiSessionToken")
                     if (!passedToken) passedToken = request.getHeader("moquiSessionToken") ?:


### PR DESCRIPTION
The line of code removed introduces some inconsistent behavior to the session token requirement. It basically says that if a session token was just created then it is not to be validated (assuming because the caller still doesn't have it). This is not aligned with our claim that a session token is require for all non-GET requests, instead we get this behavior:

**First Attempt with new Session:**
1. GET /rest/s1/test/publicApi1 -> 200
2. POST /rest/s1/test/publicApi2 -> Session token required (in X-CSRF-Token) for URL ...

**Second Attempt with new Session:**
1. POST /rest/s1/test/publicApi2 -> 200 !

