### PR TITLE
Refactor getTitle to prioritize title() method call over data

### DIFF
--- a/framework/src/main/groovy/org/moqui/impl/context/NotificationMessageImpl.groovy
+++ b/framework/src/main/groovy/org/moqui/impl/context/NotificationMessageImpl.groovy
@@ -173,16 +173,18 @@ class NotificationMessageImpl implements NotificationMessage, Externalizable {
     @Override NotificationMessage title(String title) { titleTemplate = title; return this }
     @Override String getTitle() {
         if (titleText == null) {
-            EntityValue localNotTopic = getNotificationTopic()
-            if (localNotTopic != null) {
-                if (type == danger && localNotTopic.errorTitleTemplate) {
-                    titleText = ecfi.resource.expand((String) localNotTopic.errorTitleTemplate, "", getMessageMap(), true)
-                } else if (localNotTopic.titleTemplate) {
-                    titleText = ecfi.resource.expand((String) localNotTopic.titleTemplate, "", getMessageMap(), true)
+            if (titleTemplate != null && !titleTemplate.isEmpty())
+                titleText = ecfi.resource.expand(titleTemplate, "", getMessageMap(), true)
+            if (titleText == null || titleText.isEmpty()) {
+                EntityValue localNotTopic = getNotificationTopic()
+                if (localNotTopic != null) {
+                    if (type == danger && localNotTopic.errorTitleTemplate) {
+                        titleText = ecfi.resource.expand((String) localNotTopic.errorTitleTemplate, "", getMessageMap(), true)
+                    } else if (localNotTopic.titleTemplate) {
+                        titleText = ecfi.resource.expand((String) localNotTopic.titleTemplate, "", getMessageMap(), true)
+                    }
                 }
             }
-            if ((titleText == null || titleText.isEmpty()) && titleTemplate != null && !titleTemplate.isEmpty())
-                titleText = ecfi.resource.expand(titleTemplate, "", getMessageMap(), true)
         }
         return titleText
     }


### PR DESCRIPTION
First use the titleTemplate from the title(String) method, then if the titleText is null or empty use the notification topic's titleTemplate / errorTitleTemplate.

Calling the title method should override the data because the title method is more granular and can change the title on a case by case basis.