### PR TITLE
Allow for properties to be marked "is-secret" so their values don't get printed into the log at startup.

### DIFF
--- a/framework/src/main/groovy/org/moqui/impl/context/ExecutionContextFactoryImpl.groovy
+++ b/framework/src/main/groovy/org/moqui/impl/context/ExecutionContextFactoryImpl.groovy
@@ -390,28 +390,27 @@ class ExecutionContextFactoryImpl implements ExecutionContextFactory {
         // set default System properties now that all is merged
         for (MNode defPropNode in baseConfigNode.children("default-property")) {
             String propName = defPropNode.attribute("name")
+            boolean isSecret = "true".equals(defPropNode.attribute("is-secret")) || propName.contains("pass") || propName.contains("pw") || propName.contains("key")
             if (System.getProperty(propName)) {
-                if (propName.contains("pass") || propName.contains("pw") || propName.contains("key")) {
+                if (isSecret) {
                     logger.info("Found pw/key property ${propName}, not setting from env var or default")
                 } else {
                     logger.info("Found property ${propName} with value [${System.getProperty(propName)}], not setting from env var or default")
                 }
                 continue
-            }
-            if (System.getenv(propName) && !System.getProperty(propName)) {
+            } else if (System.getenv(propName)) {
                 // make env vars available as Java System properties
                 System.setProperty(propName, System.getenv(propName))
-                if (propName.contains("pass") || propName.contains("pw") || propName.contains("key")) {
+                if (isSecret) {
                     logger.info("Setting pw/key property ${propName} from env var")
                 } else {
                     logger.info("Setting property ${propName} from env var with value [${System.getProperty(propName)}]")
                 }
-            }
-            if (!System.getProperty(propName) && !System.getenv(propName)) {
+            } else {
                 String valueAttr = defPropNode.attribute("value")
                 if (valueAttr != null && !valueAttr.isEmpty()) {
                     System.setProperty(propName, SystemBinding.expand(valueAttr))
-                    if (propName.contains("pass") || propName.contains("pw") || propName.contains("key")) {
+                    if (isSecret) {
                         logger.info("Setting pw/key property ${propName} from default")
                     } else {
                         logger.info("Setting property ${propName} from default with value [${System.getProperty(propName)}]")

--- a/framework/xsd/moqui-conf-3.xsd
+++ b/framework/xsd/moqui-conf-3.xsd
@@ -49,6 +49,7 @@ along with this software (see the LICENSE.md file). If not, see
         <xs:complexType>
             <xs:attribute name="name" type="xs:string" use="required"/>
             <xs:attribute name="value" type="xs:string" use="required"/>
+            <xs:attribute name="is-secret" type="boolean" default="false"/>
         </xs:complexType>
     </xs:element>
 


### PR DESCRIPTION
While integrating keycloak into moqui, several parameters needed to be added to the component, set via environment variables.  Those names were of the form "MOQUI_KEYCLOAK_*".  The existing code looks at the property name, and for anything that matches "*KEY*" considers it a secret, and doesn't print it's value.

While the attached patch does *not* fix that particular issue, it does make the secret-value handling more explicit, via a boolean that can be set in MoquiConf.xml.  My recommendation is to have this patch accepted, then start to deprecate the existing property name pattern matching, in preference for is-secret="true". 