### PR TITLE
Improved log4j2 configuration

### DIFF
--- a/framework/src/main/resources/log4j2.xml
+++ b/framework/src/main/resources/log4j2.xml
@@ -35,15 +35,15 @@ https://logging.apache.org/log4j/2.x/manual/layouts.html#PatternLayout
             <DefaultRolloverStrategy max="20"/>
         </RollingFile>
         <MoquiLog4jAppender name="MoquiSubscribers"/>
+        <Console name="STDOUT" target="SYSTEM_OUT">
+            <PatternLayout pattern="%highlight{%d{HH:mm:ss.SSS} %5p %12.12t %38.38c{1.9.1.}} %m%n"/>
+        </Console>
         <Async name="AsyncLog">
             <AppenderRef ref="STDOUT"/>
             <AppenderRef ref="LogFile"/>
             <AppenderRef ref="ErrorFile"/>
             <AppenderRef ref="MoquiSubscribers"/>
         </Async>
-        <Console name="STDOUT" target="SYSTEM_OUT">
-            <PatternLayout pattern="%highlight{%d{HH:mm:ss.SSS} %5p %12.12t %38.38c{1.9.1.}} %m%n"/>
-        </Console>
     </Appenders>
     <Loggers>
         <Logger name="org.apache" level="warn"/>


### PR DESCRIPTION
In the moqui-framework log4j2.xml configuration file, the Async Appender references the Console Appender and it is positioned before to the Console Appender, while the official log4j2 documentation states that - 

_The AsyncAppender should be configured after the appenders it references to allow it to shut down properly._

Reference - https://logging.apache.org/log4j/log4j-2.3.1/manual/appenders.html#AsyncAppender

Ideally the Async Appender should be placed after all the other Appenders.



