### PR TITLE
Fixed message queue clearance logic in ec.message.clearAll() method

### DIFF
--- a/framework/src/main/groovy/org/moqui/impl/context/MessageFacadeImpl.groovy
+++ b/framework/src/main/groovy/org/moqui/impl/context/MessageFacadeImpl.groovy
@@ -144,9 +144,9 @@ class MessageFacadeImpl implements MessageFacade {
 
     @Override
     void clearAll() {
+        clearErrors()
         if (messageList != null) messageList.clear()
         if (publicMessageList != null) publicMessageList.clear()
-        clearErrors()
     }
     @Override
     void clearErrors() {


### PR DESCRIPTION
The ec.message.clearAll() method is intended to clear all messages from the queue, but due to the current implementation, it fails to do so. 

The method operates by first clearing the message list and then calling the clearErrors() method. 
The clearErrors() method is designed to clear error messages from the queue, but as part of its operation, it inadvertently adds an error message back into the messageList. 

This behavior results in the clearAll method being unable to fully clear the message queue, as error messages get reintroduced after the attempt to clear them.
