### PR TITLE
allow tracking of artifact hits for rest paths (defaults to false)

### DIFF
--- a/framework/src/main/groovy/org/moqui/impl/service/RestApi.groovy
+++ b/framework/src/main/groovy/org/moqui/impl/service/RestApi.groovy
@@ -570,6 +570,7 @@ class RestApi {
         PathNode parent
         List<String> fullPathList = []
         Set<String> pathParameters = new LinkedHashSet<String>()
+        String trackArtifactHit
 
         int childPaths = 0
         int childMethods = 0
@@ -589,6 +590,7 @@ class RestApi {
             fullPathList.add(isId ? "{${name}}".toString() : name)
             if (isId) pathParameters.add(name)
             requireAuthentication = node.attribute("require-authentication") ?: parent?.requireAuthentication ?: "true"
+            trackArtifactHit = node.attribute("track-artifact-hit") ?: parent?.trackArtifactHit ?: "false"
 
             for (MNode childNode in node.children) {
                 if (childNode.name == "method") {
@@ -645,8 +647,6 @@ class RestApi {
             // push onto artifact stack, check authz
             String curPath = getFullPathName([])
             ArtifactExecutionInfoImpl aei = new ArtifactExecutionInfoImpl(curPath, ArtifactExecutionInfo.AT_REST_PATH, getActionFromMethod(ec), null)
-            // for now don't track/count artifact hits for REST path
-            aei.setTrackArtifactHit(false)
             // NOTE: consider setting parameters on aei, but don't like setting entire context, currently used for entity/service calls
             ec.artifactExecutionFacade.pushInternal(aei, !moreInPath ?
                     (requireAuthentication == null || requireAuthentication.length() == 0 || "true".equals(requireAuthentication)) : false, true)
@@ -659,6 +659,9 @@ class RestApi {
                 ec.artifactExecutionFacade.setAnonymousAuthorizedView()
                 loggedInAnonymous = ec.userFacade.loginAnonymousIfNoUser()
             }
+
+            aei.setTrackArtifactHit("true".equals(trackArtifactHit))
+            aei.setAuthzReqdAndIsAccess(!loggedInAnonymous, true)
 
             try {
                 if (moreInPath) {

--- a/framework/xsd/moqui-conf-3.xsd
+++ b/framework/xsd/moqui-conf-3.xsd
@@ -158,6 +158,7 @@ along with this software (see the LICENSE.md file). If not, see
                 <xs:enumeration value="AT_XML_SCREEN_TRANS"/>
                 <xs:enumeration value="AT_SERVICE"/>
                 <xs:enumeration value="AT_ENTITY"/>
+                <xs:enumeration value="AT_REST_PATH"/>
             </xs:restriction></xs:simpleType></xs:attribute>
             <!-- Removed, note that entity-auto and entity-implicit service calls never have hits persisted and that is
                 mainly what this was used for: <xs:attribute name="sub-type" type="xs:string"/> -->

--- a/framework/xsd/rest-api-3.xsd
+++ b/framework/xsd/rest-api-3.xsd
@@ -29,6 +29,10 @@ along with this software (see the LICENSE.md file). If not, see
             <xs:attribute name="description" type="xs:string"/>
             <xs:attribute name="version" type="xs:string"/>
             <xs:attribute name="require-authentication" type="authc-options" default="true"/>
+            <xs:attribute name="track-artifact-hit" type="xs:string" default="false">
+                <xs:annotation><xs:documentation>If set to true, ArtifactHit and ArtifactHitBin data will be kept for
+                    this rest path unless overridden by child node(s)</xs:documentation></xs:annotation>
+            </xs:attribute>
         </xs:complexType>
     </xs:element>
     <xs:element name="id">
@@ -40,6 +44,10 @@ along with this software (see the LICENSE.md file). If not, see
             </xs:sequence>
             <xs:attribute name="name" type="xs:string" use="required"/>
             <xs:attribute name="require-authentication" type="authc-options" default="true"/>
+            <xs:attribute name="track-artifact-hit" type="xs:string" default="false">
+                <xs:annotation><xs:documentation>If set to true, ArtifactHit and ArtifactHitBin data will be kept for
+                    this rest path unless overridden by child node(s)</xs:documentation></xs:annotation>
+            </xs:attribute>
             <xs:attribute name="allow-extra-path" type="boolean" default="false">
                 <xs:annotation><xs:documentation>If set to true arbitrary path elements following this screen's path are allowed.
                     Default is false and an exception will be thrown if there is an extra path element that does not match a
@@ -67,6 +75,10 @@ along with this software (see the LICENSE.md file). If not, see
                 </xs:simpleType>
             </xs:attribute>
             <xs:attribute name="require-authentication" type="authc-options" default="true"/>
+            <xs:attribute name="track-artifact-hit" type="xs:string" default="false">
+                <xs:annotation><xs:documentation>If set to true, ArtifactHit and ArtifactHitBin data will be kept for
+                    this rest path unless overridden by child node(s)</xs:documentation></xs:annotation>
+            </xs:attribute>
         </xs:complexType>
     </xs:element>
     <xs:element name="service">


### PR DESCRIPTION
Changes to enable tracking of artifact hits for rest paths. Together with PR in moqui-runtime repository.