### PR TITLE
Add SSO login using access token

### DIFF
--- a/framework/service/org/moqui/impl/UserServices.xml
+++ b/framework/service/org/moqui/impl/UserServices.xml
@@ -96,7 +96,7 @@ along with this software (see the LICENSE.md file). If not, see
             </else-if></if>
         </actions>
     </service>
-    <service verb="update" noun="UserAccount">
+    <service verb="update" noun="UserAccount" authenticate="anonymous-all" allow-remote="false">
         <in-parameters>
             <parameter name="userId" required="true"/>
             <auto-parameters entity-name="moqui.security.UserAccount" include="nonpk">

--- a/framework/src/main/groovy/org/moqui/impl/context/ExecutionContextFactoryImpl.groovy
+++ b/framework/src/main/groovy/org/moqui/impl/context/ExecutionContextFactoryImpl.groovy
@@ -1642,6 +1642,7 @@ class ExecutionContextFactoryImpl implements ExecutionContextFactory {
         if (overrideNode.hasChild("user-facade")) {
             MNode ufBaseNode = baseNode.first("user-facade")
             MNode ufOverrideNode = overrideNode.first("user-facade")
+            ufBaseNode.attributes.putAll(ufOverrideNode.attributes)
             ufBaseNode.mergeSingleChild(ufOverrideNode, "password")
             ufBaseNode.mergeSingleChild(ufOverrideNode, "login-key")
             ufBaseNode.mergeSingleChild(ufOverrideNode, "login")

--- a/framework/src/main/groovy/org/moqui/impl/context/ResourceFacadeImpl.groovy
+++ b/framework/src/main/groovy/org/moqui/impl/context/ResourceFacadeImpl.groovy
@@ -24,6 +24,7 @@ import org.moqui.impl.context.runner.JavaxScriptRunner
 import org.moqui.impl.context.runner.XmlActionsScriptRunner
 import org.moqui.impl.entity.EntityValueBase
 import org.moqui.jcache.MCache
+import org.moqui.security.SingleSignOnTokenLoginHandler
 import org.moqui.util.ContextBinding
 import org.moqui.util.ContextStack
 import org.moqui.util.MNode
@@ -59,6 +60,7 @@ class ResourceFacadeImpl implements ResourceFacade {
 
     final FtlTemplateRenderer ftlTemplateRenderer
     final XmlActionsScriptRunner xmlActionsScriptRunner
+    protected final ToolFactory<SingleSignOnTokenLoginHandler> ssoTokenHandlerFactory = null
 
     // the groovy Script object is not thread safe, so have one per thread per expression; can be reused as thread is reused
     protected final ThreadLocal<Map<String, Script>> threadScriptByExpression = new ThreadLocal<>()
@@ -162,6 +164,16 @@ class ResourceFacadeImpl implements ResourceFacade {
                 }
             } catch (Exception e) {
                 logger.error("Error getting JCR Repository ${repositoryNode.attribute("name")}: ${e.toString()}")
+            }
+        }
+
+        MNode userFacadeNode = ecfi.confXmlRoot.first("user-facade")
+        if (userFacadeNode.attribute("sso-access-token-handler-factory")) {
+            ssoTokenHandlerFactory = ecfi.getToolFactory(userFacadeNode.attribute("sso-access-token-handler-factory"))
+            if (ssoTokenHandlerFactory != null) {
+                logger.info("Using sso-access-token-handler-factory ${userFacadeNode.attribute("sso-access-token-handler-factory")} (${ssoTokenHandlerFactory.class.name})")
+            } else {
+                logger.warn("Could not find sso-access-token-handler-factory with name ${userFacadeNode.attribute("sso-access-token-handler-factory")}")
             }
         }
     }

--- a/framework/src/main/groovy/org/moqui/impl/context/UserFacadeImpl.groovy
+++ b/framework/src/main/groovy/org/moqui/impl/context/UserFacadeImpl.groovy
@@ -17,6 +17,7 @@ import groovy.transform.CompileStatic
 import org.apache.shiro.authc.AuthenticationToken
 import org.apache.shiro.authc.ExpiredCredentialsException
 import org.moqui.context.PasswordChangeRequiredException
+import org.moqui.security.SingleSignOnTokenLoginHandler
 
 import javax.websocket.server.HandshakeRequest
 import java.sql.Timestamp
@@ -171,6 +172,14 @@ class UserFacadeImpl implements UserFacade {
             loginKey = loginKey.trim()
             if (loginKey != null && !loginKey.isEmpty() && !"null".equals(loginKey) && !"undefined".equals(loginKey))
                 this.loginUserKey(loginKey)
+        }
+        if (currentInfo.username == null && request.getHeader("sso_access_token")) {
+            String ssoAccessToken = request.getHeader("sso_access_token").trim()
+            String ssoAuthFlowId = request.getHeader("sso_auth_flow")
+            if (ssoAuthFlowId)
+                ssoAuthFlowId = ssoAuthFlowId.trim()
+            if (!ssoAccessToken.isEmpty() && !"null".equals(ssoAccessToken) && !"undefined".equals(ssoAccessToken))
+                this.loginSsoToken(ssoAccessToken, ssoAuthFlowId)
         }
         if (currentInfo.username == null && secureParameters.authUsername) {
             // try the Moqui-specific parameters for instant login
@@ -800,6 +809,15 @@ class UserFacadeImpl implements UserFacade {
                 .condition("thruDate", EntityCondition.LESS_THAN, fromDate).disableAuthz().deleteAll()
 
         return loginKey
+    }
+
+    @Override boolean loginSsoToken(String ssoAccessToken, String ssoAuthFlowId) {
+        if (eci.resourceFacade.ssoTokenHandlerFactory == null) {
+            eci.logger.error("No SingleSignOnTokenLoginHandler ToolFactory configured, cannot handle SsoToken login")
+            return false
+        }
+        final SingleSignOnTokenLoginHandler ssoTokenLoginHandler = eci.resourceFacade.ssoTokenHandlerFactory.getInstance()
+        return ssoTokenLoginHandler.handleSsoLoginToken(eci, ssoAccessToken, ssoAuthFlowId)
     }
 
     @Override boolean loginAnonymousIfNoUser() {

--- a/framework/src/main/java/org/moqui/context/UserFacade.java
+++ b/framework/src/main/java/org/moqui/context/UserFacade.java
@@ -105,6 +105,12 @@ public interface UserFacade {
     String getLoginKey();
     String getLoginKey(float expireHours);
 
+    /** Authenticate a user and make active using a SSO access token
+     * @param ssoAccessToken the accessToken provided by the SSO server
+     * @param ssoAuthFlowId the (optional) authFlowId for identifying the SSO server
+     */
+    boolean loginSsoToken(String ssoAccessToken, String ssoAuthFlowId);
+
     /** If no user is logged in consider an anonymous user logged in. For internal purposes to run things that require authentication. */
     boolean loginAnonymousIfNoUser();
 

--- a/framework/src/main/java/org/moqui/security/SingleSignOnTokenLoginHandler.java
+++ b/framework/src/main/java/org/moqui/security/SingleSignOnTokenLoginHandler.java
@@ -1,0 +1,7 @@
+package org.moqui.security;
+
+import org.moqui.context.ExecutionContext;
+
+public interface SingleSignOnTokenLoginHandler {
+    public boolean handleSsoLoginToken(ExecutionContext ec, String ssoAccessToken, String ssoAuthFlowId);
+}

--- a/framework/xsd/moqui-conf-3.xsd
+++ b/framework/xsd/moqui-conf-3.xsd
@@ -335,6 +335,7 @@ along with this software (see the LICENSE.md file). If not, see
                 <xs:element minOccurs="0" ref="login-key"/>
                 <xs:element minOccurs="0" ref="login"/>
             </xs:sequence>
+            <xs:attribute name="sso-access-token-handler-factory" type="xs:string"/>
         </xs:complexType>
     </xs:element>
     <xs:element name="password">


### PR DESCRIPTION
Add capability to log into the system by using a login_token issued by a known identity provider (like Keycloak or another OpenId capable system), fetching user data from identity provider as specified by the registered mappings. This is handled by a configured access token handler, available through e.g. the moqui-sso component.