### PR TITLE
Add support for CSV escape character to EntityDataLoaderImpl

### DIFF
--- a/framework/src/main/groovy/org/moqui/impl/entity/EntityDataLoaderImpl.groovy
+++ b/framework/src/main/groovy/org/moqui/impl/entity/EntityDataLoaderImpl.groovy
@@ -75,6 +75,7 @@ class EntityDataLoaderImpl implements EntityDataLoader {
     char csvDelimiter = ','
     char csvCommentStart = '#'
     char csvQuoteChar = '"'
+    char csvEscapeChar = '\\'
 
     String csvEntityName = null
     List<String> csvFieldNames = null
@@ -925,6 +926,7 @@ class EntityDataLoaderImpl implements EntityDataLoader {
                     .withSkipHeaderRecord(true) // TODO: remove this? does it even do anything?
                     .withIgnoreEmptyLines(true)
                     .withIgnoreSurroundingSpaces(true)
+                    .withEscape(edli.csvEscapeChar)
                     .parse(reader)
 
             Iterator<CSVRecord> iterator = parser.iterator()


### PR DESCRIPTION
fixes: #641

Add CSV escape character support to EntityDataLoaderImpl

- Introduced the `csvEscapeChar` property to define the escape character used in CSV parsing.
- Updated CSV parsing configuration to use the defined escape character.

This change allows for handling escape sequences in CSV files, dealing with special characters within quoted fields.