### PR TITLE
fix: Unable to release Session : Caused by: java.io.NotSerializableEx…

### DIFF
--- a/framework/src/main/java/org/moqui/util/RestClient.java
+++ b/framework/src/main/java/org/moqui/util/RestClient.java
@@ -14,7 +14,7 @@
 package org.moqui.util;
 
 import groovy.json.JsonBuilder;
-import groovy.json.JsonSlurper;
+import groovy.json.JsonSlurperClassic;
 import org.eclipse.jetty.client.HttpClient;
 import org.eclipse.jetty.client.HttpClientTransport;
 import org.eclipse.jetty.client.HttpResponseException;
@@ -442,7 +442,7 @@ public class RestClient {
         /** Parse the response as JSON and return an Object */
         public Object jsonObject() {
             try {
-                return new JsonSlurper().parseText(text());
+                return new JsonSlurperClassic().parseText(text());
             } catch (Throwable t) {
                 throw new BaseException("Error parsing JSON response from request to " + rci.uriString, t);
             }


### PR DESCRIPTION
When using the RestClient with Quarkus i get the following error:

Unable to release Session Session@31de25{id=node019rmfggeeuvve15gdkfqxto4bg5,x=node019rmfggeeuvve15gdkfqxto4bg5.node0,req=0,res=true}
org.eclipse.jetty.server.session.UnwriteableSessionDataException: Unwriteable session node019rmfggeeuvve15gdkfqxto4bg5 for node0__0.0.0.0
.....
Caused by: java.io.NotSerializableException: org.apache.groovy.json.internal.LazyMap
	at java.io.ObjectOutputStream.writeObject0(ObjectOutputStream.java:1175) ~[?:?]
	at java.io.ObjectOutputStream.writeObject(ObjectOutputStream.java:345) ~[?:?]
	at java.util.HashMap.internalWriteEntries(HashMap.java:1858) ~[?:?]

the Lazy Map from jsonSlurper is not serializable

when replaced with the classic version solves the problem.
