### PR TITLE
Add Romanian localization

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -62,6 +62,7 @@ Written in 2021 by Deepak Dixit - dixitdeepak
 Written in 2021 by Taher Alkhateeb - pythys
 Written in 2022 by Zhang Wei - hellozhangwei
 Written in 2023 by Rohit Pawar - rohitpawar2811
+Written in 2025 by Groza Danut - grozadanut
 
 ===========================================================================
 
@@ -110,5 +111,6 @@ Written in 2021 by Deepak Dixit - dixitdeepak
 Written in 2021 by Taher Alkhateeb - pythys
 Written in 2022 by Zhang Wei - hellozhangwei
 Written in 2023 by Rohit Pawar - rohitpawar2811
+Written in 2025 by Groza Danut - grozadanut
 
 ===========================================================================

--- a/framework/data/CurrencyData.xml
+++ b/framework/data/CurrencyData.xml
@@ -139,7 +139,7 @@ along with this software (see the LICENSE.md file). If not, see
     <moqui.basic.Uom abbreviation="PLZ" description="Poland" uomId="PLZ" uomTypeEnumId="UT_CURRENCY_MEASURE"/>
     <moqui.basic.Uom abbreviation="PYG" description="Paraguayan Guarani" uomId="PYG" uomTypeEnumId="UT_CURRENCY_MEASURE"/>
     <moqui.basic.Uom abbreviation="QAR" description="Qatar Riyal" uomId="QAR" uomTypeEnumId="UT_CURRENCY_MEASURE"/>
-    <moqui.basic.Uom abbreviation="ROL" description="Romanian Leu" uomId="ROL" uomTypeEnumId="UT_CURRENCY_MEASURE"/>
+    <moqui.basic.Uom abbreviation="RON" description="Romanian Leu" uomId="RON" uomTypeEnumId="UT_CURRENCY_MEASURE"/>
     <moqui.basic.Uom abbreviation="RUR" description="Russian Rouble" uomId="RUR" uomTypeEnumId="UT_CURRENCY_MEASURE"/>
     <moqui.basic.Uom abbreviation="RWF" description="Rwanda Franc" uomId="RWF" uomTypeEnumId="UT_CURRENCY_MEASURE"/>
     <moqui.basic.Uom abbreviation="SAR" description="Saudi Riyal" uomId="SAR" uomTypeEnumId="UT_CURRENCY_MEASURE"/>


### PR DESCRIPTION
Romanian currency ROL was replaced in 2005 with RON