### PR TITLE
Updated the `moqui.server.Visit` relationship type from `one` to `one-nofk` to remove the foreign key constraint on the Visit entity.

### DIFF
--- a/framework/entity/SecurityEntities.xml
+++ b/framework/entity/SecurityEntities.xml
@@ -416,7 +416,7 @@ along with this software (see the LICENSE.md file). If not, see
         <field name="successfulLogin" type="text-indicator"/>
         <relationship type="one-nofk" related="moqui.security.UserAccount" short-alias="user">
             <description>No FK in order to allow externally authenticated users.</description></relationship>
-        <relationship type="one" related="moqui.server.Visit" short-alias="visit"/>
+        <relationship type="one-nofk" related="moqui.server.Visit" short-alias="visit"/>
     </entity>
     <entity entity-name="UserPasswordHistory" package="moqui.security" use="nontransactional" cache="never">
         <field name="userId" type="id" is-pk="true"/>

--- a/framework/entity/ServiceEntities.xml
+++ b/framework/entity/ServiceEntities.xml
@@ -194,7 +194,7 @@ along with this software (see the LICENSE.md file). If not, see
             <key-map field-name="parentMessageId" related="systemMessageId"/></relationship>
         <relationship type="one" title="Ack" related="moqui.service.message.SystemMessage" short-alias="ackMessage">
             <key-map field-name="ackMessageId" related="systemMessageId"/></relationship>
-        <relationship type="one" title="Trigger" related="moqui.server.Visit" short-alias="triggerVisit">
+        <relationship type="one-nofk" title="Trigger" related="moqui.server.Visit" short-alias="triggerVisit">
             <key-map field-name="triggerVisitId"/></relationship>
 
         <relationship type="many" related="moqui.service.message.SystemMessageError" short-alias="errors">


### PR DESCRIPTION
### Motivation
The `one` relationship type generates a database-level foreign key (FK) constraint, which causes issues during **visit data purging**. When visit/visitor records are purged, the FK constraint prevents deletion of related records, leading to constraint violations.

This aligns with the existing pattern used in `ArtifactHit`, which already uses `one-nofk` for its Visit relationship — reinforcing that FK constraints are not appropriate for transient session/visit data.

- Visit and visitor data is **transient/purgeable** by nature — maintaining a hard FK reference defeats the purpose of data purging
- Consistent with how `ArtifactHit` handles the same relationship
- No functional impact on query behavior; the logical relationship is preserved without the DB constraint
- Enables clean purging of visit/visitor data without constraint violations