### PR TITLE
Enhancing Dynamic Views in Moqui: Expanding Capabilities for Flexible Query Construction

### DIFF
--- a/framework/src/main/groovy/org/moqui/impl/entity/EntityDynamicViewImpl.groovy
+++ b/framework/src/main/groovy/org/moqui/impl/entity/EntityDynamicViewImpl.groovy
@@ -43,15 +43,7 @@ class EntityDynamicViewImpl implements EntityDynamicView {
     @Override
     EntityDynamicView addMemberEntity(String entityAlias, String entityName, String joinFromAlias, Boolean joinOptional,
                                       Map<String, String> entityKeyMaps) {
-        MNode memberEntity = entityNode.append("member-entity", ["entity-alias":entityAlias, "entity-name":entityName])
-        if (joinFromAlias) {
-            memberEntity.attributes.put("join-from-alias", joinFromAlias)
-            memberEntity.attributes.put("join-optional", (joinOptional ? "true" : "false"))
-        }
-        if (entityKeyMaps) for (Map.Entry<String, String> keyMapEntry in entityKeyMaps.entrySet()) {
-            memberEntity.append("key-map", ["field-name":keyMapEntry.getKey(), "related":keyMapEntry.getValue()])
-        }
-        return this
+        return addMemberEntity(entityAlias, entityName, joinFromAlias, joinOptional, entityKeyMaps, null, null)
     }
     EntityDynamicView addMemberEntity(String entityAlias, String entityName, String joinFromAlias, Boolean joinOptional,
                                       Map<String, String> entityKeyMaps, Map<String, String> entityConditions, String subSelect) {
@@ -144,18 +136,6 @@ class EntityDynamicViewImpl implements EntityDynamicView {
         MNode viewLink = entityNode.append("relationship", ["type":type, "title":title, "related":relatedEntityName])
         for (Map.Entry<String, String> keyMapEntry in entityKeyMaps.entrySet()) {
             viewLink.append("key-map", ["field-name":keyMapEntry.getKey(), "related":keyMapEntry.getValue()])
-        }
-        return this
-    }
-    EntityDynamicView addWhereConditions(List<Map<String, String>> conditions) {
-        if (!conditions || conditions.isEmpty()) return this
-        String nodeName = "entity-condition"
-        if (!entityNode.hasChild(nodeName)) {
-            entityNode.append(nodeName, null)
-        }
-        MNode conditionNode = entityNode.first(nodeName)
-        conditions.each { cond ->
-            conditionNode.append("econdition", ["entity-alias": cond["entity-alias"] ?: "", "field-name"  : cond["field-name"] ?: "", "operator"    : cond["operator"] ?: "equals", "value"       : cond["value"] ?: ""] as Map<String, String>)
         }
         return this
     }

--- a/framework/src/main/groovy/org/moqui/impl/entity/EntityDynamicViewImpl.groovy
+++ b/framework/src/main/groovy/org/moqui/impl/entity/EntityDynamicViewImpl.groovy
@@ -53,6 +53,30 @@ class EntityDynamicViewImpl implements EntityDynamicView {
         }
         return this
     }
+    EntityDynamicView addMemberEntity(String entityAlias, String entityName, String joinFromAlias, Boolean joinOptional,
+                                      Map<String, String> entityKeyMaps, Map<String, String> entityConditions, String subSelect) {
+        MNode memberEntity = entityNode.append("member-entity", ["entity-alias":entityAlias, "entity-name":entityName])
+        if (joinFromAlias) {
+            memberEntity.attributes.put("join-from-alias", joinFromAlias)
+            memberEntity.attributes.put("join-optional", (joinOptional ? "true" : "false"))
+        }
+        if (entityKeyMaps) for (Map.Entry<String, String> keyMapEntry in entityKeyMaps.entrySet()) {
+            memberEntity.append("key-map", ["field-name":keyMapEntry.getKey(), "related":keyMapEntry.getValue()])
+        }
+        // Add entity-condition if provided
+        if (entityConditions && !entityConditions.isEmpty()) {
+            MNode entityCondition = memberEntity.append("entity-condition", null)
+            for (Map.Entry<String, String> keyValueEntry in entityConditions.entrySet()) {
+                entityCondition.append("econdition", ["entity-alias": entityAlias, "field-name": keyValueEntry.getKey(), "value": keyValueEntry.getValue()])
+            }
+        }
+        // Handle subSelect
+        if (subSelect) {
+            memberEntity.attributes.put("sub-select", subSelect)
+        }
+
+        return this
+    }
 
     @Override
     EntityDynamicView addRelationshipMember(String entityAlias, String joinFromAlias, String relationshipName,

--- a/framework/src/main/groovy/org/moqui/impl/entity/EntityDynamicViewImpl.groovy
+++ b/framework/src/main/groovy/org/moqui/impl/entity/EntityDynamicViewImpl.groovy
@@ -147,4 +147,16 @@ class EntityDynamicViewImpl implements EntityDynamicView {
         }
         return this
     }
+    EntityDynamicView addWhereConditions(List<Map<String, String>> conditions) {
+        if (!conditions || conditions.isEmpty()) return this
+        String nodeName = "entity-condition"
+        if (!entityNode.hasChild(nodeName)) {
+            entityNode.append(nodeName, null)
+        }
+        MNode conditionNode = entityNode.first(nodeName)
+        conditions.each { cond ->
+            conditionNode.append("econdition", ["entity-alias": cond["entity-alias"] ?: "", "field-name"  : cond["field-name"] ?: "", "operator"    : cond["operator"] ?: "equals", "value"       : cond["value"] ?: ""] as Map<String, String>)
+        }
+        return this
+    }
 }

--- a/framework/src/main/java/org/moqui/entity/EntityDynamicView.java
+++ b/framework/src/main/java/org/moqui/entity/EntityDynamicView.java
@@ -29,6 +29,8 @@ public interface EntityDynamicView {
 
     EntityDynamicView addMemberEntity(String entityAlias, String entityName, String joinFromAlias,
                                              Boolean joinOptional, Map<String, String> entityKeyMaps);
+    EntityDynamicView addMemberEntity(String entityAlias, String entityName, String joinFromAlias, Boolean joinOptional,
+                                      Map<String, String> entityKeyMaps, Map<String, String> entityConditions, String subSelect);
 
     EntityDynamicView addRelationshipMember(String entityAlias, String joinFromAlias, String relationshipName,
                                                    Boolean joinOptional);


### PR DESCRIPTION

Closes: https://github.com/moqui/moqui-framework/issues/654 

Overview
This MR introduces enhancements to EntityDynamicViewImpl, improving its flexibility in handling complex query structures. The goal is to make dynamic views more powerful by supporting conditional joins, sub-selects, and potential future improvements.

Key Enhancements
✅ Conditional Joins Support

Added the ability to define custom join conditions when adding member entities.

This allows more control over how entities are joined dynamically.

✅ Sub-Select (Nested Query) Support

Enabled the use of static views as member entities in dynamic views.

This allows for sub-select queries, improving query reusability and efficiency.

