### PR TITLE
Upgrade Dependencies

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -62,6 +62,7 @@ Written in 2021 by Deepak Dixit - dixitdeepak
 Written in 2021 by Taher Alkhateeb - pythys
 Written in 2022 by Zhang Wei - hellozhangwei
 Written in 2023 by Rohit Pawar - rohitpawar2811
+Written in 2025 by Marwan Dessouki - marwand
 
 ===========================================================================
 
@@ -110,5 +111,6 @@ Written in 2021 by Deepak Dixit - dixitdeepak
 Written in 2021 by Taher Alkhateeb - pythys
 Written in 2022 by Zhang Wei - hellozhangwei
 Written in 2023 by Rohit Pawar - rohitpawar2811
+Written in 2025 by Marwan Dessouki - marwand
 
 ===========================================================================

--- a/framework/build.gradle
+++ b/framework/build.gradle
@@ -72,14 +72,14 @@ dependencies {
     //     from true during constructor to false later on; see EntityFindBuilder.java:112-114 and EntityDefinition.groovy:50-53,94-95;
     //     for now using Boolean instead of boolean to resolve, but staying at 3.0.9 to avoid risk with other code
     // Now using latest Groovy in 3 series (with code adjustments as needed)
-    api 'org.codehaus.groovy:groovy:3.0.19' // Apache 2.0
-    api 'org.codehaus.groovy:groovy-dateutil:3.0.19' // Apache 2.0
-    api 'org.codehaus.groovy:groovy-groovysh:3.0.19' // Apache 2.0
+    api 'org.codehaus.groovy:groovy:3.0.24' // Apache 2.0
+    api 'org.codehaus.groovy:groovy-dateutil:3.0.24' // Apache 2.0
+    api 'org.codehaus.groovy:groovy-groovysh:3.0.24' // Apache 2.0
     // jline, an older version, is required by groovy-groovysh but not in its dependencies
     implementation 'jline:jline:2.14.6' // BSD
-    api 'org.codehaus.groovy:groovy-json:3.0.19' // Apache 2.0
-    api 'org.codehaus.groovy:groovy-templates:3.0.19' // Apache 2.0
-    api 'org.codehaus.groovy:groovy-xml:3.0.19' // Apache 2.0
+    api 'org.codehaus.groovy:groovy-json:3.0.24' // Apache 2.0
+    api 'org.codehaus.groovy:groovy-templates:3.0.24' // Apache 2.0
+    api 'org.codehaus.groovy:groovy-xml:3.0.24' // Apache 2.0
     // jansi is needed for groovydoc only, so in compileOnly (not included in war) - don't update to version 2, keep at version 1 for compatibility
     compileOnly 'org.fusesource.jansi:jansi:1.18'
     // Findbugs need only during compile (used by freemarker and various moqui classes)
@@ -89,21 +89,21 @@ dependencies {
 
     // Bitronix Transaction Manager (the default internal tx mgr; custom build from source as 3.0.0 not yet released)
     api 'org.codehaus.btm:btm:3.0.0-20161020' // Apache 2.0
-    runtimeOnly 'org.javassist:javassist:3.29.2-GA' // Apache 2.0
+    runtimeOnly 'org.javassist:javassist:3.30.2-GA' // Apache 2.0
 
     // ========== General Libraries from Maven Central ==========
 
     // Apache Commons
     api 'org.apache.commons:commons-csv:1.14.0' // Apache 2.0
     // NOTE: commons-email depends on com.sun.mail:javax.mail, included below, so use module() here to not get dependencies
-    api module('org.apache.commons:commons-email:1.5') // Apache 2.0
+    api module('org.apache.commons:commons-email:1.6.0') // Apache 2.0
     api 'org.apache.commons:commons-lang3:3.17.0' // Apache 2.0; used by cron-utils
     api 'commons-beanutils:commons-beanutils:1.10.1' // Apache 2.0
     api 'commons-codec:commons-codec:1.18.0' // Apache 2.0
     api 'commons-collections:commons-collections:3.2.2' // Apache 2.0
     api 'commons-digester:commons-digester:2.1' // Apache 2.0
     api 'commons-fileupload:commons-fileupload:1.5' // Apache 2.0
-    api 'commons-io:commons-io:2.18.0' // Apache 2.0
+    api 'commons-io:commons-io:2.19.0' // Apache 2.0
     api 'commons-logging:commons-logging:1.3.5' // Apache 2.0
     api 'commons-validator:commons-validator:1.9.0' // Apache 2.0
 
@@ -145,7 +145,7 @@ dependencies {
     api 'com.beust:jcommander:1.82'
 
     // Jackson Databind (JSON, etc)
-    api 'com.fasterxml.jackson.core:jackson-databind:2.18.3'
+    api 'com.fasterxml.jackson.core:jackson-databind:2.19.0'
 
     // Jetty HTTP Client and Proxy Servlet
     api 'org.eclipse.jetty:jetty-client:10.0.25' // Apache 2.0
@@ -156,10 +156,10 @@ dependencies {
     api module('com.sun.mail:javax.mail:1.6.2') // CDDL
 
     // Joda Time (used by elasticsearch, aws)
-    api 'joda-time:joda-time:2.13.1' // Apache 2.0
+    api 'joda-time:joda-time:2.14.0' // Apache 2.0
 
     // JSoup (HTML parser, cleaner)
-    api 'org.jsoup:jsoup:1.19.1' // MIT
+    api 'org.jsoup:jsoup:1.20.1' // MIT
 
     // Apache Shiro
     api module('org.apache.shiro:shiro-core:1.13.0') // Apache 2.0
@@ -191,16 +191,16 @@ dependencies {
     // ========== test dependencies ==========
 
     // junit-platform-launcher is a dependency from spock-core, included explicitly to get more recent version as needed
-    testImplementation 'org.junit.platform:junit-platform-launcher:1.12.1'
+    testImplementation 'org.junit.platform:junit-platform-launcher:1.12.2'
     // junit-platform-suite required for test suites to specify test class order, etc
-    testImplementation 'org.junit.platform:junit-platform-suite:1.12.1'
+    testImplementation 'org.junit.platform:junit-platform-suite:1.12.2'
     // junit-jupiter-api for using JUnit directly, not generally needed for Spock based tests
-    testImplementation 'org.junit.jupiter:junit-jupiter-api:5.12.1'
+    testImplementation 'org.junit.jupiter:junit-jupiter-api:5.12.2'
     // Spock Framework
-    testImplementation platform("org.spockframework:spock-bom:2.1-groovy-3.0") // Apache 2.0
-    testImplementation 'org.spockframework:spock-core:2.1-groovy-3.0' // Apache 2.0
-    testImplementation 'org.spockframework:spock-junit4:2.1-groovy-3.0' // Apache 2.0
-    testImplementation 'org.hamcrest:hamcrest-core:2.2' // BSD 3-Clause
+    testImplementation platform("org.spockframework:spock-bom:2.3-groovy-3.0") // Apache 2.0
+    testImplementation 'org.spockframework:spock-core:2.3-groovy-3.0' // Apache 2.0
+    testImplementation 'org.spockframework:spock-junit4:2.3-groovy-3.0' // Apache 2.0
+    testImplementation 'org.hamcrest:hamcrest-core:3.0' // BSD 3-Clause
 
     // ========== executable war dependencies ==========
     // Jetty

--- a/framework/src/main/groovy/org/moqui/impl/util/RestSchemaUtil.groovy
+++ b/framework/src/main/groovy/org/moqui/impl/util/RestSchemaUtil.groovy
@@ -582,7 +582,7 @@ class RestSchemaUtil {
 
         if (extraPathNameList.size() == 0) {
             List allRefList = []
-            Map definitionsMap = [:]
+            Map<String, Object> definitionsMap = [:]
             definitionsMap.put('paginationParameters', jsonPaginationParameters)
             Map rootMap = ['$schema':'http://json-schema.org/draft-04/hyper-schema#', title:'Moqui Entity REST API',
                     anyOf:allRefList, definitions:definitionsMap]


### PR DESCRIPTION
  
The following dependencies were upgraded to new versions:
 - com.fasterxml.jackson.core:jackson-databind [2.18.3 -> 2.19.0]
     https://github.com/FasterXML/jackson  
 - commons-io:commons-io [2.18.0 -> 2.19.0] 
     https://commons.apache.org/proper/commons-io/  
 - joda-time:joda-time [2.13.1 -> 2.14.0] 
     https://www.joda.org/joda-time/  
 - org.apache.commons:commons-email [1.5 -> 1.6.0]  
     https://commons.apache.org/proper/commons-email/  
- org.codehaus.groovy:groovy [3.0.19 -> 3.0.24]  
     https://groovy-lang.org  
 - org.codehaus.groovy:groovy-dateutil [3.0.19 -> 3.0.24]  
     https://groovy-lang.org  
 - org.codehaus.groovy:groovy-groovysh [3.0.19 -> 3.0.24]  
     https://groovy-lang.org  
 - org.codehaus.groovy:groovy-json [3.0.19 -> 3.0.24]  
     https://groovy-lang.org  
 - org.codehaus.groovy:groovy-templates [3.0.19 -> 3.0.24]  
     https://groovy-lang.org  
 - org.codehaus.groovy:groovy-xml [3.0.19 -> 3.0.24]  
     https://groovy-lang.org  
-  org.hamcrest:hamcrest-core [2.2 -> 3.0]  
     http://hamcrest.org/JavaHamcrest/  
 - org.javassist:javassist [3.29.2-GA -> 3.30.2-GA]  
     https://www.javassist.org/  
 - org.jsoup:jsoup [1.19.1 -> 1.20.1]  
     https://jsoup.org/  
 - org.junit.jupiter:junit-jupiter-api [5.12.1 -> 5.12.2]  
     https://junit.org/junit5/  
 - org.junit.platform:junit-platform-launcher [1.12.1 -> 1.12.2]  
     https://junit.org/junit5/  
 - org.junit.platform:junit-platform-suite [1.12.1 -> 1.12.2]  
     https://junit.org/junit5/  
 - org.spockframework:spock-bom [2.1-groovy-3.0 -> 2.3-groovy-3.0]  
     https://spockframework.org  
 - org.spockframework:spock-core [2.1-groovy-3.0 -> 2.3-groovy-30]  
     https://spockframework.org  
 - org.spockframework:spock-junit4 [2.1-groovy-3.0 -> 2.3-groovy-3.0]  
     https://spockframework.org  

The following were skipped:
- org.fusesource.jansi:jansi [1.18 -> 2.4.2]
	Reason: As mentioned in build.gradle,  "jansi is needed for groovydoc only, so in compileOnly (not included in war) - don't update to version 2, keep at version 1 for"

The following need further work to be upgraded (Jakarta, breaking changes, etc..)
 - org.apache.shiro:shiro-core [1.13.0 -> 2.0.4]  
     https://shiro.apache.org/shiro-core/  
 - org.apache.shiro:shiro-web [1.13.0 -> 2.0.4]  
     https://shiro.apache.org/shiro-web/  
 - org.eclipse.jetty:jetty-client [10.0.25 -> 12.0.21]  
     https://jetty.org  
 - org.eclipse.jetty:jetty-jndi [10.0.25 -> 12.0.21]  
     https://jetty.org  
 - org.eclipse.jetty:jetty-proxy [10.0.25 -> 12.0.21]  
     https://jetty.org  
 - org.eclipse.jetty:jetty-server [10.0.25 -> 12.0.21]  
     https://jetty.org  
 - org.eclipse.jetty:jetty-webapp [10.0.25 -> 11.0.25]  
     https://jetty.org  
 - org.eclipse.jetty.websocket:websocket-jetty-server [10.0.25 -> 11.0.25]  
     https://jetty.org  
     
Testing:
- I ran ./gradlew cleanPullTest and all tests have passed with the exception of the NoSql db related ones – wasn't able to get the orientdb setup working properly (Is it still maintained?) - I would appreciate some assistance here.

- I ran ./gradlew load, ./gradlew run, everything looks good.

![image](https://github.com/user-attachments/assets/62a4dd27-7989-4ee4-acb2-aadfa8e37985)


