### PR TITLE
Added support for createdStamp field on all entity definitions

### DIFF
--- a/framework/src/main/groovy/org/moqui/impl/entity/EntityDefinition.groovy
+++ b/framework/src/main/groovy/org/moqui/impl/entity/EntityDefinition.groovy
@@ -221,6 +221,7 @@ class EntityDefinition {
             if (internalEntityNode.attribute("no-update-stamp") != "true") {
                 // automatically add the lastUpdatedStamp field
                 internalEntityNode.append("field", [name:"lastUpdatedStamp", type:"date-time"])
+                internalEntityNode.append("field", [name:"createdStamp", type:"date-time"])
             }
 
             ArrayList<MNode> fieldNodeList = internalEntityNode.children("field")
@@ -431,6 +432,7 @@ class EntityDefinition {
                 String aliasName = fi.name
                 // never auto-alias these
                 if ("lastUpdatedStamp".equals(aliasName)) continue
+                if ("createdStamp".equals(aliasName)) continue
                 // if specified as excluded, leave it out
                 ArrayList<MNode> excludeList = aliasAll.children("exclude")
                 int excludeListSize = excludeList.size()

--- a/framework/src/main/groovy/org/moqui/impl/entity/EntityJavaUtil.java
+++ b/framework/src/main/groovy/org/moqui/impl/entity/EntityJavaUtil.java
@@ -276,6 +276,7 @@ public class EntityJavaUtil {
 
         public final FieldInfo[] pkFieldInfoArray, nonPkFieldInfoArray, allFieldInfoArray;
         final FieldInfo lastUpdatedStampInfo;
+        final FieldInfo createdStampInfo;
         public final String allFieldsSqlSelect;
         final Map<String, String> pkFieldDefaults, nonPkFieldDefaults;
 
@@ -362,7 +363,7 @@ public class EntityJavaUtil {
             boolean hasFunctionAliasTemp = false;
             Map<String, String> pkFieldDefaultsTemp = new HashMap<>();
             Map<String, String> nonPkFieldDefaultsTemp = new HashMap<>();
-            FieldInfo lastUpdatedTemp = null;
+            FieldInfo lastUpdatedTemp = null, createdStampTemp = null;
             for (int i = 0; i < allFieldInfoSize; i++) {
                 FieldInfo fi = allFieldInfoList.get(i);
                 allFieldInfoArray[i] = fi;
@@ -386,6 +387,8 @@ public class EntityJavaUtil {
                     else nonPkFieldDefaultsTemp.put(fi.name, defaultStr);
                 }
                 if ("lastUpdatedStamp".equals(fi.name)) lastUpdatedTemp = fi;
+                if ("createdStamp".equals(fi.name)) createdStampTemp = fi;
+
             }
             createOnlyFields = createOnlyFieldsTemp;
             needsAuditLog = needsAuditLogTemp;
@@ -395,6 +398,7 @@ public class EntityJavaUtil {
             pkFieldDefaults = pkFieldDefaultsTemp.size() > 0 ? pkFieldDefaultsTemp : null;
             nonPkFieldDefaults = nonPkFieldDefaultsTemp.size() > 0 ? nonPkFieldDefaultsTemp : null;
             lastUpdatedStampInfo = lastUpdatedTemp;
+            createdStampInfo = createdStampTemp;
 
             pkFieldInfoArray = new FieldInfo[pkFieldInfoList.size()];
             pkFieldInfoList.toArray(pkFieldInfoArray);

--- a/framework/src/main/groovy/org/moqui/impl/entity/EntityValueBase.java
+++ b/framework/src/main/groovy/org/moqui/impl/entity/EntityValueBase.java
@@ -982,6 +982,7 @@ public abstract class EntityValueBase implements EntityValue {
             for (String nonpkFieldName : this.getEntityDefinition().getNonPkFieldNames()) {
                 // skip the lastUpdatedStamp field
                 if ("lastUpdatedStamp".equals(nonpkFieldName)) continue;
+                if ("createdStamp".equals(nonpkFieldName)) continue;
 
                 final Object checkFieldValue = this.get(nonpkFieldName);
                 final Object dbFieldValue = dbValue.get(nonpkFieldName);
@@ -1035,6 +1036,7 @@ public abstract class EntityValueBase implements EntityValue {
             for (String nonpkFieldName : this.getEntityDefinition().getNonPkFieldNames()) {
                 // skip the lastUpdatedStamp field
                 if ("lastUpdatedStamp".equals(nonpkFieldName)) continue;
+                if ("createdStamp".equals(nonpkFieldName)) continue;
 
                 final Object checkFieldValue = this.get(nonpkFieldName);
                 final Object dbFieldValue = dbValue.get(nonpkFieldName);
@@ -1510,8 +1512,12 @@ public abstract class EntityValueBase implements EntityValue {
         final Long time = ecfi.transactionFacade.getCurrentTransactionStartTime();
         Long lastUpdatedLong = time != null && time > 0 ? time : System.currentTimeMillis();
         FieldInfo lastUpdatedStampInfo = ed.entityInfo.lastUpdatedStampInfo;
+        FieldInfo createdStampInfo = ed.entityInfo.createdStampInfo;
         if (lastUpdatedStampInfo != null && valueMapInternal.getByIString(lastUpdatedStampInfo.name, lastUpdatedStampInfo.index) == null)
             valueMapInternal.putByIString(lastUpdatedStampInfo.name, new Timestamp(lastUpdatedLong), lastUpdatedStampInfo.index);
+
+        if (createdStampInfo != null && valueMapInternal.getByIString(createdStampInfo.name, createdStampInfo.index) == null)
+            valueMapInternal.putByIString(createdStampInfo.name, new Timestamp(lastUpdatedLong), createdStampInfo.index);
 
         // do the artifact push/authz
         ArtifactExecutionInfoImpl aei = new ArtifactExecutionInfoImpl(entityName, ArtifactExecutionInfo.AT_ENTITY, ArtifactExecutionInfo.AUTHZA_CREATE, "create").setParameters(valueMapInternal);


### PR DESCRIPTION
- Automatically appends createdStamp alongside lastUpdatedStamp during entity initialization.
- Sets createdStamp during record creation, if not already provided.

Provides an immutable timestamp indicating when the record was first created.
When investigating issues, it allows you to track when a record entered the system — crucial for reproducing bugs or identifying anomalies.
Adds a valuable dimension to BI tools, dashboards, and data exports.