### PR TITLE
To solve the Bitronix Transaction Manager cannot access the JDK 17  internal APIs.

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: java -cp . MoquiStart port=5000 conf=conf/MoquiProductionConf.xml
+web: java -cp . --add-opens=java.base/java.lang=ALL-UNNAMED MoquiStart port=5000 conf=conf/MoquiProductionConf.xml

--- a/Procfile.README
+++ b/Procfile.README
@@ -1,5 +1,7 @@
 No memory or other JVM options specified here so that the standard JAVA_TOOL_OPTIONS env var may be used (command line args trump JAVA_TOOL_OPTIONS)
 
+Note: Must have --add-opens=java.base/java.lang=ALL-UNNAMED to jvm arguments run with java 17+
+
 For example: export JAVA_TOOL_OPTIONS="-Xmx1024m -Xms1024m"
 Note that in Java 8 if no max heap size is specified it will default to 1/4 system memory
 

--- a/build.gradle
+++ b/build.gradle
@@ -621,14 +621,18 @@ task gitMergeAll {
 
 task run(type: JavaExec) {
     dependsOn checkRuntime, allBuildTasks, cleanTempDir
+
     workingDir = '.'; jvmArgs = ['-server', '-XX:-OmitStackTraceInFastThrow', '--add-opens=java.base/java.lang=ALL-UNNAMED', '--add-opens=java.base/java.util=ALL-UNNAMED', '--add-opens=java.base/java.net=ALL-UNNAMED', '--add-opens=java.management/javax.management=ALL-UNNAMED']
+
     systemProperties = ['moqui.conf':moquiConfDev, 'moqui.runtime':moquiRuntime]
     // NOTE: this is a hack, using -jar instead of a class name, and then the first argument is the name of the jar file
     main = '-jar'; args = [warName]
 }
 task runProduction(type: JavaExec) {
     dependsOn checkRuntime, allBuildTasks, cleanTempDir
+
     workingDir = '.'; jvmArgs = ['-server', '-Xms1024M', '--add-opens=java.base/java.lang=ALL-UNNAMED', '--add-opens=java.base/java.util=ALL-UNNAMED', '--add-opens=java.base/java.net=ALL-UNNAMED', '--add-opens=java.management/javax.management=ALL-UNNAMED']
+
     systemProperties = ['moqui.conf':moquiConfProduction, 'moqui.runtime':moquiRuntime]
     main = '-jar'; args = [warName]
 }
@@ -637,25 +641,33 @@ task load(type: JavaExec) {
     description "Run Moqui to load data; to specify data types use something like: gradle load -Ptypes=seed,seed-initial,install"
     dependsOn checkRuntime, allBuildTasks
     systemProperties = ['moqui.conf':moquiConfDev, 'moqui.runtime':moquiRuntime]
+
     workingDir = '.'; jvmArgs = ['-server', '--add-opens=java.base/java.lang=ALL-UNNAMED', '--add-opens=java.base/java.util=ALL-UNNAMED', '--add-opens=java.base/java.net=ALL-UNNAMED', '--add-opens=java.management/javax.management=ALL-UNNAMED']; main = '-jar'
+
     args = [warName, 'load', (project.properties.containsKey('types') ? "types=${types}" : "types=all")]
 }
 task loadSeed(type: JavaExec) {
     dependsOn checkRuntime, allBuildTasks
     systemProperties = ['moqui.conf':moquiConfProduction, 'moqui.runtime':moquiRuntime]
+
     workingDir = '.'; jvmArgs = ['-server', '--add-opens=java.base/java.lang=ALL-UNNAMED', '--add-opens=java.base/java.util=ALL-UNNAMED', '--add-opens=java.base/java.net=ALL-UNNAMED', '--add-opens=java.management/javax.management=ALL-UNNAMED']; main = '-jar'
+
     args = [warName, 'load', (project.properties.containsKey('types') ? "types=${types}" : "types=seed")]
 }
 task loadSeedInitial(type: JavaExec) {
     dependsOn checkRuntime, allBuildTasks
     systemProperties = ['moqui.conf':moquiConfProduction, 'moqui.runtime':moquiRuntime]
+
     workingDir = '.'; jvmArgs = ['-server', '--add-opens=java.base/java.lang=ALL-UNNAMED', '--add-opens=java.base/java.util=ALL-UNNAMED', '--add-opens=java.base/java.net=ALL-UNNAMED', '--add-opens=java.management/javax.management=ALL-UNNAMED']; main = '-jar'
+
     args = [warName, 'load', (project.properties.containsKey('types') ? "types=${types}" : "types=seed,seed-initial")]
 }
 task loadProduction(type: JavaExec) {
     dependsOn checkRuntime, allBuildTasks
     systemProperties = ['moqui.conf':moquiConfProduction, 'moqui.runtime':moquiRuntime]
+
     workingDir = '.'; jvmArgs = ['-server', '--add-opens=java.base/java.lang=ALL-UNNAMED', '--add-opens=java.base/java.util=ALL-UNNAMED', '--add-opens=java.base/java.net=ALL-UNNAMED', '--add-opens=java.management/javax.management=ALL-UNNAMED']; main = '-jar'
+
     args = [warName, 'load', (project.properties.containsKey('types') ? "types=${types}" : "types=seed,seed-initial,install")]
 }
 

--- a/docker/build-compose-up.sh
+++ b/docker/build-compose-up.sh
@@ -1,14 +1,14 @@
 #! /bin/bash
 
 if [[ ! $1 ]]; then
-  echo "Usage: ./build-compose-up.sh <docker compose file> [<moqui directory like ..>] [<runtime image like eclipse-temurin:11-jdk>]"
+  echo "Usage: ./build-compose-up.sh <docker compose file> [<moqui directory like ..>] [<runtime image like eclipse-temurin:17-jdk>]"
   exit 1
 fi
 
 COMP_FILE="${1}"
 MOQUI_HOME="${2:-..}"
 NAME_TAG=moqui
-RUNTIME_IMAGE="${3:-eclipse-temurin:11-jdk}"
+RUNTIME_IMAGE="${3:-eclipse-temurin:17-jdk}"
 
 if [ -f simple/docker-build.sh ]; then
   cd simple

--- a/docker/compose-up.sh
+++ b/docker/compose-up.sh
@@ -1,14 +1,14 @@
 #! /bin/bash
 
 if [[ ! $1 ]]; then
-  echo "Usage: ./compose-up.sh <docker compose file> [<moqui directory like ..>] [<runtime image like eclipse-temurin:11-jdk>]"
+  echo "Usage: ./compose-up.sh <docker compose file> [<moqui directory like ..>] [<runtime image like eclipse-temurin:17-jdk>]"
   exit 1
 fi
 
 COMP_FILE="${1}"
 MOQUI_HOME="${2:-..}"
 NAME_TAG=moqui
-RUNTIME_IMAGE="${3:-eclipse-temurin:11-jdk}"
+RUNTIME_IMAGE="${3:-eclipse-temurin:17-jdk}"
 
 # Note: If you don't have access to your conf directory while running this:
 #   This will make it so that your docker/conf directory no longer has your configuration files in it.

--- a/docker/moqui-acme-postgres.yml
+++ b/docker/moqui-acme-postgres.yml
@@ -71,7 +71,7 @@ services:
   moqui-server:
     image: moqui
     container_name: moqui-server
-    command: conf=conf/MoquiProductionConf.xml no-run-es
+    command: conf=conf/MoquiProductionConf.xml no-run-es --add-opens=java.base/java.lang=ALL-UNNAMED
     restart: always
     links:
       - moqui-database

--- a/docker/moqui-run.sh
+++ b/docker/moqui-run.sh
@@ -1,11 +1,11 @@
 #! /bin/bash
 
-echo "Usage: moqui-run.sh [<moqui directory like ..>] [<group/name:tag>] [<runtime image like eclipse-temurin:11-jdk>]"
+echo "Usage: moqui-run.sh [<moqui directory like ..>] [<group/name:tag>] [<runtime image like eclipse-temurin:17-jdk>]"
 echo
 
 MOQUI_HOME="${1:-..}"
 NAME_TAG="${2:-moqui}"
-RUNTIME_IMAGE="${3:-eclipse-temurin:11-jdk}"
+RUNTIME_IMAGE="${3:-eclipse-temurin:17-jdk}"
 
 search_name=opensearch
 if [ -d "$MOQUI_HOME/runtime/opensearch/bin" ]; then search_name=opensearch;

--- a/docker/simple/Dockerfile
+++ b/docker/simple/Dockerfile
@@ -1,6 +1,6 @@
 # Builds a minimal docker image with openjdk and moqui with various volumes for configuration and persisted data outside the container
 # NOTE: add components, build and if needed load data before building a docker image with this
-ARG RUNTIME_IMAGE=eclipse-temurin:11-jdk
+ARG RUNTIME_IMAGE=eclipse-temurin:17-jdk
 FROM ${RUNTIME_IMAGE}
 MAINTAINER Moqui Framework <moqui@googlegroups.com>
 
@@ -49,7 +49,9 @@ EXPOSE 5701
 
 # this is to run from the war file directly, preferred approach unzips war file in advance
 # ENTRYPOINT ["java", "-jar", "moqui.war"]
+
 ENTRYPOINT ["java", "--add-opens=java.base/java.lang=ALL-UNNAMED", "--add-opens=java.base/java.util=ALL-UNNAMED", "--add-opens=java.base/java.net=ALL-UNNAMED", "--add-opens=java.management/javax.management=ALL-UNNAMED", "-cp", ".", "MoquiStart", "port=80"]
+
 
 HEALTHCHECK --interval=30s --timeout=600ms --start-period=120s CMD curl -f -H "X-Forwarded-Proto: https" -H "X-Forwarded-Ssl: on" http://localhost/status || exit 1
 # specify this as a default parameter if none are specified with docker exec/run, ie run production by default

--- a/docker/simple/docker-build.sh
+++ b/docker/simple/docker-build.sh
@@ -1,13 +1,13 @@
 #! /bin/bash
 
-echo "Usage: docker-build.sh [<moqui directory like ../..>] [<group/name:tag>] [<runtime image like eclipse-temurin:11-jdk>]"
+echo "Usage: docker-build.sh [<moqui directory like ../..>] [<group/name:tag>] [<runtime image like eclipse-temurin:17-jdk>]"
 
 MOQUI_HOME="${1:-../..}"
 NAME_TAG="${2:-moqui}"
-RUNTIME_IMAGE="${3:-eclipse-temurin:11-jdk}"
+RUNTIME_IMAGE="${3:-eclipse-temurin:17-jdk}"
 
 if [ ! "$1" ]; then
-  echo "Usage: docker-build.sh [<moqui directory like ../..>] [<group/name:tag>] [<runtime image like eclipse-temurin:11-jdk>]"
+  echo "Usage: docker-build.sh [<moqui directory like ../..>] [<group/name:tag>] [<runtime image like eclipse-temurin:17-jdk>]"
 else
   echo "Running: docker-build.sh $MOQUI_HOME $NAME_TAG $RUNTIME_IMAGE"
 fi

--- a/framework/build.gradle
+++ b/framework/build.gradle
@@ -262,7 +262,7 @@ war {
     destinationDirectory = projectDir.parentFile
     archiveFileName = 'moqui.war'
     // add MoquiInit.properties to the WEB-INF/classes dir for the deployed war mode of operation
-    from(fileTree(dir: destinationDir, includes: ['MoquiInit.properties'])) { into 'WEB-INF/classes' }
+    from(fileTree(dir: destinationDirectory, includes: ['MoquiInit.properties'])) { into 'WEB-INF/classes' }
     // this excludes the classes in sourceSets.main.output (better to have the jar file built above)
     classpath = configurations.runtimeClasspath - configurations.providedCompile
     classpath file(jar.archivePath)


### PR DESCRIPTION
JDK17 startup error: main .moqui.i.e.EntityDatasourceFactoryImpl Error connecting to DataSource transactional (mysql8), try 1 of 5: java.lang.reflect.InaccessibleObjectException: Unable to make protected final java.lang.Class

This is because:
JDK 17 has enhanced the module system: The module system introduced starting from JDK 9 has become more strict in JDK 17.
Reflection access restrictions: JDK 17 does not allow reflective access to internal classes of the java.base module by default.
Bitronix transaction manager: The Bitronix transaction manager used in the project needs access to JDK internal APIs.

JVM parameter explanations:
--add-opens=java.base/java.lang=ALL-UNNAMED: Opens access to the java.lang package.
--add-opens=java.base/java.util=ALL-UNNAMED: Opens access to the java.util package.
--add-opens=java.base/java.net=ALL-UNNAMED: Opens access to the java.net package.
--add-opens=java.management/javax.management=ALL-UNNAMED: Opens access related to JMX management.

These parameters tell the JVM to allow unnamed modules (application code) to access these protected modules, thereby resolving the issue where the Bitronix transaction manager cannot access JDK internal APIs. Now your Moqui project should start normally on JDK 17!