### PR TITLE
fix: exclude old jakarta.mail and jakarta.activation dependencies fro…

### DIFF
--- a/framework/build.gradle
+++ b/framework/build.gradle
@@ -68,7 +68,11 @@ dependencies {
 
     // Apache Commons
     api 'org.apache.commons:commons-csv:1.14.1' // Apache 2.0
-    api 'org.apache.commons:commons-email2-jakarta:2.0.0-M1'
+    api('org.apache.commons:commons-email2-jakarta:2.0.0-M1') {
+        exclude group: 'com.sun.mail', module: 'jakarta.mail'
+        exclude group: 'com.sun.activation', module: 'jakarta.activation'
+    }
+
     api 'org.apache.commons:commons-collections4:4.5.0' // Apache 2.0
     api 'org.apache.commons:commons-fileupload2-jakarta-servlet6:2.0.0-M4' // Apache 2.0
     api 'commons-codec:commons-codec:1.20.0' // Apache 2.0


### PR DESCRIPTION
fix: exclude old jakarta.mail and jakarta.activation dependencies from 'org.apache.commons:commons-email2-jakarta:2.0.0-M1

This avoids including the older jakarta.activation:2.0.1 and jakarta.mail-2.0.1 dependencies, which overlap the already included jakarta.activation-api:2.1.4 and jakarta.mail-api-2.1.5.