### PR TITLE
Add breadcrumbItems to menuData for custom breadcrumb rendering

### DIFF
--- a/framework/src/main/groovy/org/moqui/impl/screen/ScreenRenderImpl.groovy
+++ b/framework/src/main/groovy/org/moqui/impl/screen/ScreenRenderImpl.groovy
@@ -2442,9 +2442,35 @@ class ScreenRenderImpl implements ScreenRender {
             int extraPathListSize = extraPathList.size()
             for (int i = 0; i < extraPathListSize; i++) extraPathList.set(i, StringUtilities.urlEncodeIfNeeded((String) extraPathList.get(i)))
         }
+        List<Map> breadcrumbItems = null
+        Object breadcrumbItemsObj = ec.contextStack.getByString("screenBreadcrumbItems")
+        if (breadcrumbItemsObj instanceof Collection) {
+            breadcrumbItems = new LinkedList<>()
+            for (Object itemObj in (Collection) breadcrumbItemsObj) {
+                if (!(itemObj instanceof Map)) continue
+                Map item = (Map) itemObj
+                String title = item.get("title") != null ? item.get("title").toString() : null
+                if (title == null || title.isEmpty()) continue
+                Map crumbMap = [title:title]
+                Object pathWithParamsObj = item.get("pathWithParams")
+                if (pathWithParamsObj != null) {
+                    String crumbPathWithParams = pathWithParamsObj.toString()
+                    if (!crumbPathWithParams.isEmpty()) crumbMap.pathWithParams = crumbPathWithParams
+                } else {
+                    Object pathObj = item.get("path")
+                    if (pathObj != null) {
+                        String crumbPath = pathObj.toString()
+                        if (!crumbPath.isEmpty()) crumbMap.pathWithParams = crumbPath
+                    }
+                }
+                breadcrumbItems.add(crumbMap)
+            }
+            if (breadcrumbItems.isEmpty()) breadcrumbItems = null
+        }
         Map lastMap = [name:lastPathItem, title:lastTitle, path:lastPath, pathWithParams:currentPath.toString(),
                 image:lastImage, imageType:lastImageType, extraPathList:extraPathList, screenDocList:screenDocList,
                 renderModes:fullUrlInfo.targetScreen.renderModes, savedFinds:savedFindsList]
+        if (breadcrumbItems != null) lastMap.breadcrumbItems = breadcrumbItems
         menuDataList.add(lastMap)
         // not needed: screenStatic:fullUrlInfo.targetScreen.isServerStatic(renderMode)
 


### PR DESCRIPTION
# Add breadcrumbItems to menuData for custom breadcrumb rendering

## Problem
The header breadcrumb UI only had enough data to render the default path/title pattern. We need a way for screens to provide custom breadcrumb states and links.

## Use Case
Some screens need custom breadcrumb trails (including intermediate links and non-link labels) that differ from default menu depth/title rendering, so users can navigate contextual paths correctly.

## What Changed
- Read optional `screenBreadcrumbItems` from the context stack.
- Normalize breadcrumb entries to a safe list of maps containing:
  - `title` (required)
  - `pathWithParams` (optional; falls back from `pathWithParams` to `path` when available)
- Ignore invalid/empty breadcrumb entries.
- Attach normalized `breadcrumbItems` to the final `menuData` entry returned for the current target screen.

## Data Contract
Input expected in context stack:
- `screenBreadcrumbItems`: collection of maps
- Each item may include:
  - `title` (string, required)
  - `pathWithParams` (string, optional)
  - `path` (string, optional fallback)

Output added to menuData last entry:
- `breadcrumbItems`: list of `{ title, pathWithParams? }`

## Backward Compatibility
- If `screenBreadcrumbItems` is absent or empty, no `breadcrumbItems` are added.
- Existing consumers continue working unchanged.

## Validation
Manual checks:
1. Navigate to a screen with no custom breadcrumb data and confirm existing breadcrumb behavior is unchanged.
2. Provide `screenBreadcrumbItems` with mixed linked/non-linked items and confirm output contains valid normalized entries.
3. Confirm empty/invalid items are filtered out.

## Out of Scope
- Router/navigation internals are not changed in this PR.
- The Quasar warning (`Cannot read properties of undefined (reading 'catch')`) is a separate pre-existing router shim issue.

## Reviewer Focus
- Is `breadcrumbItems` naming/shape acceptable for long-term API compatibility?
- Is fallback logic (`pathWithParams` -> `path`) appropriate?
- Any edge cases to harden before merge?

## Related PR
- Runtime UI rendering PR: https://github.com/moqui/moqui-runtime/pull/247#issue-4086777717
