### PR TITLE
Moqui now honors the standard Log4j property 'log4j.configurationFile'

### DIFF
--- a/framework/src/main/groovy/org/moqui/impl/context/ExecutionContextFactoryImpl.groovy
+++ b/framework/src/main/groovy/org/moqui/impl/context/ExecutionContextFactoryImpl.groovy
@@ -306,14 +306,24 @@ class ExecutionContextFactoryImpl implements ExecutionContextFactory {
     }
 
     protected void reconfigureLog4j() {
-        URL log4j2Url = this.class.getClassLoader().getResource("log4j2.xml")
+
+        String log4jStr = SystemBinding.getPropOrEnv("log4j.configurationFile")?.trim()
+        
+        URL log4j2Url = log4jStr ?
+                new File(log4jStr).toURI().toURL() :
+                this.class.getClassLoader().getResource("log4j2.xml")
+
         if (log4j2Url == null) {
             logger.warn("No log4j2.xml file found on the classpath, no reconfiguring Log4J")
             return
         }
+        
+        logger.info("Reconfiguring Log4J with ${log4j2Url}")
+
         final LoggerContext ctx = (LoggerContext) LogManager.getContext(true)
         ctx.setConfigLocation(log4j2Url.toURI())
     }
+
 
     protected MNode initBaseConfig(MNode runtimeConfXmlRoot) {
         String version = this.class.getPackage().getImplementationVersion()


### PR DESCRIPTION
**Intention:** 

To give developers the same level of control during logging of components and the framework they have in other products using Log4j.

**What it does:**

This change  replaces the use of the hard coded `log4j.xml` from the jar resources with 

1. A use of the contents of the standard  Log4J configuration file override property (`log4j.configurationFile`) from system properties or environment variables if it is set in either.
2. If no location is found, it tries to find "log4j2.xml" on the classpath (basically, as a resource bundled with the code or libraries).
3. If it can't find a configuration file in either location, it logs a warning and stops (does not attempt to reconfigure 