### PR TITLE
Increase default Docker JVM max heap from 1024m to 4096m

### DIFF
--- a/docker/moqui-acme-postgres.yml
+++ b/docker/moqui-acme-postgres.yml
@@ -87,7 +87,7 @@ services:
       - ./runtime/db:/opt/moqui/runtime/db
       - ./runtime/opensearch:/opt/moqui/runtime/opensearch
     environment:
-      - "JAVA_TOOL_OPTIONS=-Xms1024m -Xmx1024m"
+      - "JAVA_TOOL_OPTIONS=-Xms1024m -Xmx4096m"
       - instance_purpose=production
       - entity_ds_db_conf=postgres
       - entity_ds_host=moqui-database

--- a/docker/moqui-cluster1-compose.yml
+++ b/docker/moqui-cluster1-compose.yml
@@ -59,7 +59,7 @@ services:
       - ./runtime/db:/opt/moqui/runtime/db
       - ./runtime/opensearch:/opt/moqui/runtime/opensearch
     environment:
-      - "JAVA_TOOL_OPTIONS=-Xms1024m -Xmx1024m"
+      - "JAVA_TOOL_OPTIONS=-Xms1024m -Xmx4096m"
       - instance_purpose=production
       - entity_ds_db_conf=mysql8
       - entity_ds_host=moqui-database
@@ -114,7 +114,7 @@ services:
       - ./runtime/sessions:/opt/moqui/runtime/sessions
       # this one isn't needed when not using H2/etc: - ./runtime/db:/opt/moqui/runtime/db
     environment:
-      - "JAVA_TOOL_OPTIONS=-Xms1024m -Xmx1024m"
+      - "JAVA_TOOL_OPTIONS=-Xms1024m -Xmx4096m"
       - instance_purpose=production
       - entity_ds_db_conf=mysql8
       - entity_ds_host=moqui-database

--- a/docker/moqui-mysql-compose.yml
+++ b/docker/moqui-mysql-compose.yml
@@ -62,7 +62,7 @@ services:
       - ./runtime/db:/opt/moqui/runtime/db
       - ./runtime/opensearch:/opt/moqui/runtime/opensearch
     environment:
-      - "JAVA_TOOL_OPTIONS=-Xms1024m -Xmx1024m"
+      - "JAVA_TOOL_OPTIONS=-Xms1024m -Xmx4096m"
       - instance_purpose=production
       - entity_ds_db_conf=mysql8
       - entity_ds_host=moqui-database

--- a/docker/moqui-postgres-compose.yml
+++ b/docker/moqui-postgres-compose.yml
@@ -57,7 +57,7 @@ services:
      - ./runtime/db:/opt/moqui/runtime/db
      - ./runtime/opensearch:/opt/moqui/runtime/opensearch
     environment:
-     - "JAVA_TOOL_OPTIONS=-Xms1024m -Xmx1024m"
+     - "JAVA_TOOL_OPTIONS=-Xms1024m -Xmx4096m"
      - instance_purpose=production
      - entity_ds_db_conf=postgres
      - entity_ds_host=moqui-database


### PR DESCRIPTION
     Production workloads with large data volumes cause OutOfMemoryError crashes
     with the current 1GB max heap default in Docker Compose templates.

     Specific failure scenarios observed in production:
     - Indexing a data document with around 34,000 records and multiple fields
     - Running the scheduled job "clean_ArtifactData_daily" to clean millions of artifact hits was crashing when I restored production data on another server

     Both operations exhausted heap space and crashed the JVM with:
         java.lang.OutOfMemoryError: Java heap space

     Bumping the -Xmx default to 4096m resolved these issues without code changes.
