### PR TITLE
Replace synchronized blocks with ReentrantLock; adopt virtual threads

### DIFF
--- a/framework/src/main/groovy/org/moqui/impl/context/CacheFacadeImpl.groovy
+++ b/framework/src/main/groovy/org/moqui/impl/context/CacheFacadeImpl.groovy
@@ -54,6 +54,7 @@ public class CacheFacadeImpl implements CacheFacade {
     protected CacheManager distCacheManagerInternal = (CacheManager) null
 
     final ConcurrentMap<String, Cache> localCacheMap = new ConcurrentHashMap<>()
+    private final java.util.concurrent.locks.ReentrantLock initCacheLock = new java.util.concurrent.locks.ReentrantLock()
 
     CacheFacadeImpl(ExecutionContextFactoryImpl ecfi) {
         this.ecfi = ecfi
@@ -189,7 +190,12 @@ public class CacheFacadeImpl implements CacheFacade {
         return cacheElement
     }
 
-    protected synchronized Cache initCache(String cacheName, String defaultCacheType) {
+    protected Cache initCache(String cacheName, String defaultCacheType) {
+        initCacheLock.lock()
+        try { return initCacheLocked(cacheName, defaultCacheType) }
+        finally { initCacheLock.unlock() }
+    }
+    private Cache initCacheLocked(String cacheName, String defaultCacheType) {
         if (localCacheMap.containsKey(cacheName)) return localCacheMap.get(cacheName)
 
         if (!defaultCacheType) defaultCacheType = "local"

--- a/framework/src/main/groovy/org/moqui/impl/context/ContextJavaUtil.java
+++ b/framework/src/main/groovy/org/moqui/impl/context/ContextJavaUtil.java
@@ -51,6 +51,7 @@ import java.util.*;
 import java.util.concurrent.*;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.locks.ReentrantLock;
 
 public class ContextJavaUtil {
     protected final static Logger logger = LoggerFactory.getLogger(ContextJavaUtil.class);
@@ -114,6 +115,7 @@ public class ContextJavaUtil {
         private String artifactSubType;
         private String artifactName;
         public ArtifactBinInfo curHitBin = null;
+        public final ReentrantLock hitBinLock = new ReentrantLock();
         private long hitCount = 0L; // slowHitCount = 0L;
         private double totalTimeMillis = 0, totalSquaredTime = 0;
 
@@ -367,6 +369,13 @@ public class ContextJavaUtil {
             txConByGroup.clear();
         }
     }
+    /** Container for the per-key list and its ReentrantLock, used by EntityRecordLock.register/clear to avoid
+     *  synchronized(list) which pins virtual thread carrier threads. */
+    public static class ErlListEntry {
+        public final ArrayList<EntityRecordLock> list = new ArrayList<>();
+        public final ReentrantLock lock = new ReentrantLock();
+    }
+
     public static class EntityRecordLock {
         // TODO enum for operation? create, update, delete, find-for-update
         String entityName, pkString, entityPlusPk, threadName;
@@ -389,14 +398,16 @@ public class ContextJavaUtil {
             return this;
         }
 
-        void register(ConcurrentHashMap<String, ArrayList<EntityRecordLock>> recordLockByEntityPk, TxStackInfo txStackInfo) {
+        void register(ConcurrentHashMap<String, ErlListEntry> recordLockByEntityPk, TxStackInfo txStackInfo) {
             if (txStackInfo != null) {
                 moquiTxId = txStackInfo.moquiTxId;
                 txBeginTime = txStackInfo.transactionBeginStartTime != null ? txStackInfo.transactionBeginStartTime : -1;
             }
 
-            ArrayList<EntityRecordLock> curErlList = recordLockByEntityPk.computeIfAbsent(entityPlusPk, k -> new ArrayList<>());
-            synchronized (curErlList) {
+            ErlListEntry entry = recordLockByEntityPk.computeIfAbsent(entityPlusPk, k -> new ErlListEntry());
+            entry.lock.lock();
+            try {
+                ArrayList<EntityRecordLock> curErlList = entry.list;
                 // is this another lock in the same transaction?
                 if (curErlList.size() > 0) {
                     for (int i = 0; i < curErlList.size(); i++) {
@@ -438,24 +449,29 @@ public class ContextJavaUtil {
                 } else {
                     logger.warn("In EntityRecordLock register no TxStackInfo so not registering lock because won't be able to clear for entity " + entityName + " pk " + pkString + " thread " + threadName);
                 }
+            } finally {
+                entry.lock.unlock();
             }
         }
-        void clear(ConcurrentHashMap<String, ArrayList<EntityRecordLock>> recordLockByEntityPk) {
-            ArrayList<EntityRecordLock> curErlList = recordLockByEntityPk.get(entityPlusPk);
-            if (curErlList == null) {
+        void clear(ConcurrentHashMap<String, ErlListEntry> recordLockByEntityPk) {
+            ErlListEntry entry = recordLockByEntityPk.get(entityPlusPk);
+            if (entry == null) {
                 logger.warn("In EntityRecordLock clear no locks found for " + entityPlusPk);
                 return;
             }
-            synchronized (curErlList) {
+            entry.lock.lock();
+            try {
                 boolean haveRemoved = false;
-                for (int i = 0; i < curErlList.size(); i++) {
-                    EntityRecordLock otherErl = curErlList.get(i);
+                for (int i = 0; i < entry.list.size(); i++) {
+                    EntityRecordLock otherErl = entry.list.get(i);
                     if (moquiTxId == otherErl.moquiTxId) {
-                        curErlList.remove(i);
+                        entry.list.remove(i);
                         haveRemoved = true;
                     }
                 }
                 if (!haveRemoved) logger.warn("In EntityRecordLock clear no locks found for " + entityPlusPk);
+            } finally {
+                entry.lock.unlock();
             }
         }
     }
@@ -649,42 +665,43 @@ public class ContextJavaUtil {
         }
     }
 
-    // NOTE: using unbound LinkedBlockingQueue, so max pool size in ThreadPoolExecutor has no effect
-    public static class WorkerThreadFactory implements ThreadFactory {
-        private final ThreadGroup workerGroup = new ThreadGroup("MoquiWorkers");
-        private final AtomicInteger threadNumber = new AtomicInteger(1);
-        public Thread newThread(Runnable r) { return new Thread(workerGroup, r, "MoquiWorker-" + threadNumber.getAndIncrement()); }
-    }
-    public static class JobThreadFactory implements ThreadFactory {
-        private final ThreadGroup workerGroup = new ThreadGroup("MoquiJobs");
-        private final AtomicInteger threadNumber = new AtomicInteger(1);
-        public Thread newThread(Runnable r) { return new Thread(workerGroup, r, "MoquiJob-" + threadNumber.getAndIncrement()); }
-    }
-    public static class WorkerThreadPoolExecutor extends ThreadPoolExecutor {
-        private ExecutionContextFactoryImpl ecfi;
-        public WorkerThreadPoolExecutor(ExecutionContextFactoryImpl ecfi, int coreSize, int maxSize, long aliveTime,
-                                        TimeUnit timeUnit, BlockingQueue<Runnable> blockingQueue, ThreadFactory threadFactory) {
-            super(coreSize, maxSize, aliveTime, timeUnit, blockingQueue, threadFactory);
+    /**
+     * Virtual thread-based ThreadPoolExecutor with safety-net ExecutionContext cleanup,
+     * with pool and queue sizing semantics.
+     */
+    public static class VirtualThreadExecutorService extends ThreadPoolExecutor {
+        private final ExecutionContextFactoryImpl ecfi;
+        private final String poolName;
+
+        public VirtualThreadExecutorService(ExecutionContextFactoryImpl ecfi, String poolName, int coreSize, int maxSize,
+                                            long aliveTime, @NotNull TimeUnit timeUnit, @NotNull BlockingQueue<Runnable> blockingQueue) {
+            super(coreSize, maxSize, aliveTime, timeUnit, blockingQueue,
+                    Thread.ofVirtual().name(poolName + "-", 1).factory());
+            // Virtual threads should not be pooled: allow core threads to terminate when idle
+            // so each task gets a fresh virtual thread rather than reusing a pooled one.
+            allowCoreThreadTimeOut(true);
             this.ecfi = ecfi;
+            this.poolName = poolName;
         }
 
         @Override protected void afterExecute(Runnable runnable, Throwable throwable) {
             ExecutionContextImpl activeEc = ecfi.activeContext.get();
             if (activeEc != null) {
-                logger.warn("In WorkerThreadPoolExecutor.afterExecute() there is still an ExecutionContext for runnable " + runnable.getClass().getName() + " in thread (" + Thread.currentThread().threadId() + ":" + Thread.currentThread().getName() + "), destroying");
+                logger.warn("EC leaked in " + poolName + " virtual thread (" +
+                        Thread.currentThread().threadId() + ":" + Thread.currentThread().getName() +
+                        ") for runnable " + runnable.getClass().getName() + ", destroying as safety net");
                 try {
                     activeEc.destroy();
                 } catch (Throwable t) {
-                    logger.error("Error destroying ExecutionContext in WorkerThreadPoolExecutor.afterExecute()", t);
+                    logger.error("Error in EC safety-net cleanup", t);
                 }
-            } else {
-                if (ecfi.transactionFacade.isTransactionInPlace()) {
-                    logger.error("In WorkerThreadPoolExecutor a transaction is in place for thread " + Thread.currentThread().getName() + ", trying to commit");
-                    try {
-                        ecfi.transactionFacade.destroyAllInThread();
-                    } catch (Exception e) {
-                        logger.error("WorkerThreadPoolExecutor commit in place transaction failed in thread " + Thread.currentThread().getName(), e);
-                    }
+            } else if (ecfi.transactionFacade != null && ecfi.transactionFacade.isTransactionInPlace()) {
+                logger.error("Transaction leaked in " + poolName + " virtual thread " +
+                        Thread.currentThread().getName() + ", trying to commit");
+                try {
+                    ecfi.transactionFacade.destroyAllInThread();
+                } catch (Exception e) {
+                    logger.error("Failed to commit leaked transaction in " + poolName, e);
                 }
             }
 
@@ -751,6 +768,44 @@ public class ContextJavaUtil {
         protected <V> RunnableScheduledFuture<V> decorateTask(Callable<V> c, RunnableScheduledFuture<V> task) {
             return new CustomScheduledTask<V>(c, task);
         }
+    }
+    // Used in delegation pattern for implementing distributed scheduled executor service
+    public static interface CustomDistributedScheduledExecutor {
+        /**
+         * Decorate any Callable with a task name to provide naming information to scheduler.
+         * For Hazelcast-backed implementations this should generally map to NamedTask/TaskUtils.named(...)
+         * so task identity is stable cluster-wide.
+         */
+        <V> Callable<V> decorateTask(String taskName, Callable<V> callable);
+        /**
+         * Decorate any Runnable with a task name to provide naming information to scheduler.
+         * For Hazelcast-backed implementations this should generally map to NamedTask/TaskUtils.named(...)
+         * so task identity is stable cluster-wide.
+         */
+        Runnable decorateTask(String taskName, Runnable runnable);
+        /** Submits a one-shot task that becomes enabled after the given delay. */
+        ScheduledFuture<?> schedule(Runnable command, long delay, TimeUnit unit);
+        /** Submits a value-returning one-shot task that becomes enabled after the given delay. */
+        <V> ScheduledFuture<V> schedule(Callable<V> callable, long delay, TimeUnit unit);
+        /** Submits a periodic action that becomes enabled first after the given initial delay, and subsequently with the given period; that is, executions will commence after initialDelay, then initialDelay + period, then initialDelay + 2 * period, and so on. */        
+        ScheduledFuture<?> scheduleAtFixedRate(Runnable command, long initialDelay, long period, TimeUnit unit);
+        /**
+         * Submits a periodic action that becomes enabled first after the given initial delay, and subsequently
+         * with the given delay between the termination of one execution and the commencement of the next.
+         *
+         * Hazelcast IScheduledExecutorService (5.6) does not provide an equivalent of
+         * ScheduledExecutorService.scheduleWithFixedDelay(...), so implementations backed by Hazelcast
+         * may leave this unsupported and throw UnsupportedOperationException.
+         */
+        default ScheduledFuture<?> scheduleWithFixedDelay(Runnable command, long initialDelay, long delay, TimeUnit unit) {
+            throw new UnsupportedOperationException("scheduleWithFixedDelay is not supported by this distributed scheduled executor");
+        }
+        /** Initiates an orderly shutdown in which previously submitted tasks are executed, but no new tasks will be accepted. */
+        void shutdown();
+        /** Get a ScheduledFuture from the given taskName, if it exists. */
+        ScheduledFuture<?> getScheduledFuture(String taskName);
+        /** Used to destroy the instance of the ScheduledFuture in the distributed scheduled executor service. */
+        void dispose(ScheduledFuture<?> scheduledFuture);
     }
     static class ScheduledRunnableInfo {
         public final Runnable command;

--- a/framework/src/main/groovy/org/moqui/impl/context/ExecutionContextFactoryImpl.groovy
+++ b/framework/src/main/groovy/org/moqui/impl/context/ExecutionContextFactoryImpl.groovy
@@ -70,6 +70,7 @@ import java.sql.Timestamp
 import java.util.concurrent.BlockingQueue
 import java.util.concurrent.ConcurrentLinkedQueue
 import java.util.concurrent.LinkedBlockingQueue
+import java.util.concurrent.ExecutorService
 import java.util.concurrent.ScheduledFuture
 import java.util.concurrent.ScheduledThreadPoolExecutor
 import java.util.concurrent.ThreadPoolExecutor
@@ -111,7 +112,8 @@ class ExecutionContextFactoryImpl implements ExecutionContextFactory {
     public final Map<Long, ExecutionContextImpl> activeContextMap = new HashMap<>()
     protected final LinkedHashMap<String, ToolFactory> toolFactoryMap = new LinkedHashMap<>()
 
-    protected final Map<String, WebappInfo> webappInfoMap = new HashMap<>()
+    protected final Map<String, WebappInfo> webappInfoMap = new java.util.concurrent.ConcurrentHashMap<>()
+    private final java.util.concurrent.locks.ReentrantLock webappInfoLock = new java.util.concurrent.locks.ReentrantLock()
     protected final List<NotificationMessageListener> registeredNotificationMessageListeners = []
 
     protected final Map<String, ArtifactStatsInfo> artifactStatsInfoByType = new HashMap<>()
@@ -147,8 +149,8 @@ class ExecutionContextFactoryImpl implements ExecutionContextFactory {
     @SuppressWarnings("GrFinalVariableAccess") public final ServiceFacadeImpl serviceFacade
     @SuppressWarnings("GrFinalVariableAccess") public final ScreenFacadeImpl screenFacade
 
-    /** The main worker pool for services, running async closures and runnables, etc */
-    @SuppressWarnings("GrFinalVariableAccess") public final ThreadPoolExecutor workerPool
+    /** The main worker pool for services, running async closures and runnables, etc (virtual thread-based) */
+    @SuppressWarnings("GrFinalVariableAccess") public final ExecutorService workerPool
     /** An executor for the scheduled job runner */
     @SuppressWarnings("GrFinalVariableAccess") public final CustomScheduledExecutor scheduledExecutor
     public final ArrayList<ScheduledRunnableInfo> scheduledRunnableList = new ArrayList<>()
@@ -447,7 +449,7 @@ class ExecutionContextFactoryImpl implements ExecutionContextFactory {
         return baseConfigNode
     }
 
-    private ThreadPoolExecutor makeWorkerPool() {
+    private ExecutorService makeWorkerPool() {
         MNode toolsNode = confXmlRoot.first('tools')
 
         int workerQueueSize = (toolsNode.attribute("worker-queue") ?: "65536") as int
@@ -462,21 +464,21 @@ class ExecutionContextFactoryImpl implements ExecutionContextFactory {
         }
         long aliveTime = (toolsNode.attribute("worker-pool-alive") ?: "60") as long
 
-        logger.info("Initializing worker ThreadPoolExecutor: queue limit ${workerQueueSize}, pool-core ${coreSize}, pool-max ${maxSize}, pool-alive ${aliveTime}s")
-        return new ContextJavaUtil.WorkerThreadPoolExecutor(this, coreSize, maxSize, aliveTime, TimeUnit.SECONDS,
-                workQueue, new ContextJavaUtil.WorkerThreadFactory())
+        logger.info("Initializing worker pool with Virtual Threads (MoquiWorker): queue limit ${workerQueueSize}, pool-core ${coreSize}, pool-max ${maxSize}, pool-alive ${aliveTime}s")
+        return new ContextJavaUtil.VirtualThreadExecutorService(this, "MoquiWorker", coreSize, maxSize, aliveTime, TimeUnit.SECONDS, workQueue)
     }
     boolean waitWorkerPoolEmpty(int retryLimit) {
-        ThreadPoolExecutor jobWorkerPool = serviceFacade.jobWorkerPool
+        ThreadPoolExecutor wp = (ThreadPoolExecutor) workerPool
+        ThreadPoolExecutor jwp = (ThreadPoolExecutor) serviceFacade.jobWorkerPool
         int count = 0
-        while (count < retryLimit && (workerPool.getQueue().size() > 0 || workerPool.getActiveCount() > 0 ||
-                jobWorkerPool.getQueue().size() > 0 || jobWorkerPool.getActiveCount() > 0)) {
-            if (count % 10 == 0) logger.warn("Wait for workerPool and jobWorkerPool empty: worker queue size ${workerPool.getQueue().size()} active ${workerPool.getActiveCount()} max threads ${workerPool.getMaximumPoolSize()}; service job queue size ${jobWorkerPool.getQueue().size()} active ${jobWorkerPool.getActiveCount()}")
+        while (count < retryLimit && (wp.getQueue().size() > 0 || wp.getActiveCount() > 0 ||
+                jwp.getQueue().size() > 0 || jwp.getActiveCount() > 0)) {
+            if (count % 10 == 0) logger.warn("Wait for workerPool and jobWorkerPool empty: worker queue size ${wp.getQueue().size()} active ${wp.getActiveCount()} max threads ${wp.getMaximumPoolSize()}; service job queue size ${jwp.getQueue().size()} active ${jwp.getActiveCount()}")
             Thread.sleep(100)
             count++
         }
-        int afterSize = workerPool.getQueue().size() + workerPool.getActiveCount()
-        int jobAfterSize = jobWorkerPool.getQueue().size() + jobWorkerPool.getActiveCount()
+        int afterSize = wp.getQueue().size() + wp.getActiveCount()
+        int jobAfterSize = jwp.getQueue().size() + jwp.getActiveCount()
         if (afterSize > 0 || jobAfterSize > 0) logger.warn("After ${retryLimit} 100ms waits worker pool size is ${afterSize} and service job pool size is ${jobAfterSize}")
         return afterSize == 0 && jobAfterSize == 0
     }
@@ -906,7 +908,7 @@ class ExecutionContextFactoryImpl implements ExecutionContextFactory {
 
     /** Trigger ECF destroy and re-init in another thread, after short wait */
     void triggerDynamicReInit() {
-        Thread.start("EcfiReInit", {
+        Thread.ofVirtual().name("EcfiReInit").start({
             sleep(2000) // wait 2 seconds
             Moqui.dynamicReInit(ExecutionContextFactoryImpl.class, internalServletContext)
         })
@@ -1064,7 +1066,14 @@ class ExecutionContextFactoryImpl implements ExecutionContextFactory {
     @Override @Nonnull ClassLoader getClassLoader() { moquiClassLoader }
     @Override @Nonnull GroovyClassLoader getGroovyClassLoader() { groovyClassLoader }
 
-    synchronized Class compileGroovy(String script, String className) {
+    private final java.util.concurrent.locks.ReentrantLock compileGroovyLock = new java.util.concurrent.locks.ReentrantLock()
+    Class compileGroovy(String script, String className) {
+        compileGroovyLock.lock()
+        try {
+        return compileGroovyInternal(script, className)
+        } finally { compileGroovyLock.unlock() }
+    }
+    private Class compileGroovyInternal(String script, String className) {
         boolean hasClassName = className != null && !className.isEmpty()
         if (groovyCompileCacheToDisk && hasClassName) {
             // if the className already exists just return it
@@ -1269,6 +1278,9 @@ class ExecutionContextFactoryImpl implements ExecutionContextFactory {
                     // if it's a directory and doesn't start with a "." then add it as a component dir
                     String subRrName = componentSubRr.getFileName()
                     if ((!componentSubRr.isDirectory() && !subRrName.endsWith(".zip")) || subRrName.startsWith(".")) continue
+                    // Skip Gradle intermediate project output dirs under runtime/component and runtime/base-component.
+                    if (componentSubRr.isDirectory() && "build".equals(subRrName) &&
+                            componentSubRr.getChild("tmp").getExists() && !componentSubRr.getChild("component.xml").getExists()) continue
                     componentDirEntries.put(componentSubRr.getFileName(), componentSubRr)
                 }
                 for (Map.Entry<String, ResourceReference> componentDirEntry in componentDirEntries.entrySet()) {
@@ -1506,7 +1518,7 @@ class ExecutionContextFactoryImpl implements ExecutionContextFactory {
         final static int maxCreates = 1000
         final ExecutionContextFactoryImpl ecfi
         DeferredHitInfoFlush(ExecutionContextFactoryImpl ecfi) { this.ecfi = ecfi }
-        @Override synchronized void run() {
+        @Override void run() {
             ExecutionContextImpl eci = ecfi.getEci()
             eci.artifactExecutionFacade.disableAuthz()
             try {
@@ -1569,28 +1581,33 @@ class ExecutionContextFactoryImpl implements ExecutionContextFactory {
         }
     }
 
-    protected synchronized void advanceArtifactHitBin(ExecutionContextImpl eci, ArtifactStatsInfo statsInfo,
+    protected void advanceArtifactHitBin(ExecutionContextImpl eci, ArtifactStatsInfo statsInfo,
             long startTime, long hitBinLengthMillis) {
-        ArtifactBinInfo abi = statsInfo.curHitBin
-        if (abi == null) {
+        statsInfo.hitBinLock.lock()
+        try {
+            ArtifactBinInfo abi = statsInfo.curHitBin
+            if (abi == null) {
+                statsInfo.curHitBin = new ArtifactBinInfo(statsInfo, startTime)
+                return
+            }
+
+            // check the time again and return just in case something got in while waiting with the same type
+            long binStartTime = abi.startTime
+            if (startTime < (binStartTime + hitBinLengthMillis)) return
+
+            // otherwise, persist the old and create a new one
+            EntityValue ahb = abi.makeAhbValue(this, new Timestamp(binStartTime + hitBinLengthMillis))
+            eci.runInWorkerThread({
+                ArtifactExecutionFacadeImpl aefi = getEci().artifactExecutionFacade
+                boolean enableAuthz = !aefi.disableAuthz()
+                try { ahb.setSequencedIdPrimary().create() }
+                finally { if (enableAuthz) aefi.enableAuthz() }
+            })
+
             statsInfo.curHitBin = new ArtifactBinInfo(statsInfo, startTime)
-            return
+        } finally {
+            statsInfo.hitBinLock.unlock()
         }
-
-        // check the time again and return just in case something got in while waiting with the same type
-        long binStartTime = abi.startTime
-        if (startTime < (binStartTime + hitBinLengthMillis)) return
-
-        // otherwise, persist the old and create a new one
-        EntityValue ahb = abi.makeAhbValue(this, new Timestamp(binStartTime + hitBinLengthMillis))
-        eci.runInWorkerThread({
-            ArtifactExecutionFacadeImpl aefi = getEci().artifactExecutionFacade
-            boolean enableAuthz = !aefi.disableAuthz()
-            try { ahb.setSequencedIdPrimary().create() }
-            finally { if (enableAuthz) aefi.enableAuthz() }
-        })
-
-        statsInfo.curHitBin = new ArtifactBinInfo(statsInfo, startTime)
     }
 
     // ========================================================
@@ -1781,11 +1798,19 @@ class ExecutionContextFactoryImpl implements ExecutionContextFactory {
         if (wi != null) return wi
         return makeWebappInfo(webappName)
     }
-    protected synchronized WebappInfo makeWebappInfo(String webappName) {
+    protected WebappInfo makeWebappInfo(String webappName) {
         if (webappName == null || webappName.isEmpty()) return null
-        WebappInfo wi = new WebappInfo(webappName, this)
-        webappInfoMap.put(webappName, wi)
-        return wi
+        webappInfoLock.lock()
+        try {
+            // re-check inside lock (DCL)
+            WebappInfo existing = webappInfoMap.get(webappName)
+            if (existing != null) return existing
+            WebappInfo wi = new WebappInfo(webappName, this)
+            webappInfoMap.put(webappName, wi)
+            return wi
+        } finally {
+            webappInfoLock.unlock()
+        }
     }
 
     static class WebappInfo {

--- a/framework/src/main/groovy/org/moqui/impl/context/ResourceFacadeImpl.groovy
+++ b/framework/src/main/groovy/org/moqui/impl/context/ResourceFacadeImpl.groovy
@@ -611,8 +611,7 @@ class ResourceFacadeImpl implements ResourceFacade {
             try { transformer.transform(xslFoSrc, new SAXResult(contentHandler)) }
             catch (Throwable t) { transformException = new BaseArtifactException("Error transforming XSL-FO to ${contentType}", t) }
         })
-        Thread transThread = new Thread(runnable)
-        transThread.start()
+        Thread transThread = Thread.ofVirtual().name("XslFoTransform").start(runnable)
         transThread.join()
         if (transformException != null) throw transformException
 

--- a/framework/src/main/groovy/org/moqui/impl/context/TransactionFacadeImpl.groovy
+++ b/framework/src/main/groovy/org/moqui/impl/context/TransactionFacadeImpl.groovy
@@ -56,7 +56,7 @@ class TransactionFacadeImpl implements TransactionFacade {
     private ThreadLocal<TxStackInfo> txStackInfoCurThread = new ThreadLocal<TxStackInfo>()
     private ThreadLocal<LinkedList<TxStackInfo>> txStackInfoListThread = new ThreadLocal<LinkedList<TxStackInfo>>()
 
-    protected final ConcurrentHashMap<String, ArrayList<EntityRecordLock>> recordLockByEntityPk = new ConcurrentHashMap<>()
+    protected final ConcurrentHashMap<String, ContextJavaUtil.ErlListEntry> recordLockByEntityPk = new ConcurrentHashMap<>()
 
     TransactionFacadeImpl(ExecutionContextFactoryImpl ecfi) {
         this.ecfi = ecfi
@@ -202,7 +202,7 @@ class TransactionFacadeImpl implements TransactionFacade {
             Throwable threadThrown = null
 
             try {
-                txThread = Thread.start('RequireNewTx', {
+                txThread = Thread.ofVirtual().name('RequireNewTx').start({
                     if (threadReuseEci) ecfi.useExecutionContextInThread(eci)
                     try {
                         if (beginTx) {

--- a/framework/src/main/groovy/org/moqui/impl/context/runner/GroovyScriptRunner.groovy
+++ b/framework/src/main/groovy/org/moqui/impl/context/runner/GroovyScriptRunner.groovy
@@ -23,11 +23,13 @@ import org.moqui.impl.context.ExecutionContextFactoryImpl
 import org.moqui.util.StringUtilities
 
 import javax.cache.Cache
+import java.util.concurrent.locks.ReentrantLock
 
 @CompileStatic
 class GroovyScriptRunner implements ScriptRunner {
     private ExecutionContextFactoryImpl ecfi
     private Cache<String, Class> scriptGroovyLocationCache
+    private final ReentrantLock loadGroovyLock = new ReentrantLock()
 
     GroovyScriptRunner() { }
 
@@ -58,13 +60,16 @@ class GroovyScriptRunner implements ScriptRunner {
         if (gc == null) gc = loadGroovy(location)
         return gc
     }
-    private synchronized Class loadGroovy(String location) {
-        Class gc = (Class) scriptGroovyLocationCache.get(location)
-        if (gc == null) {
-            String groovyText = ecfi.resourceFacade.getLocationText(location, false)
-            gc = ecfi.compileGroovy(groovyText, StringUtilities.cleanStringForJavaName(location))
-            scriptGroovyLocationCache.put(location, gc)
-        }
-        return gc
+    private Class loadGroovy(String location) {
+        loadGroovyLock.lock()
+        try {
+            Class gc = (Class) scriptGroovyLocationCache.get(location)
+            if (gc == null) {
+                String groovyText = ecfi.resourceFacade.getLocationText(location, false)
+                gc = ecfi.compileGroovy(groovyText, StringUtilities.cleanStringForJavaName(location))
+                scriptGroovyLocationCache.put(location, gc)
+            }
+            return gc
+        } finally { loadGroovyLock.unlock() }
     }
 }

--- a/framework/src/main/groovy/org/moqui/impl/entity/EntityDbMeta.groovy
+++ b/framework/src/main/groovy/org/moqui/impl/entity/EntityDbMeta.groovy
@@ -38,6 +38,7 @@ class EntityDbMeta {
     protected final static Logger logger = LoggerFactory.getLogger(EntityDbMeta.class)
 
     static final boolean useTxForMetaData = false
+    private final ReentrantLock metaCheckLock = new ReentrantLock()
 
     // this keeps track of when tables are checked and found to exist or are created
     protected HashMap<String, Timestamp> entityTablesChecked = new HashMap<>()
@@ -392,7 +393,12 @@ class EntityDbMeta {
         }
     }
 
-    synchronized boolean internalCheckTable(EntityDefinition ed, boolean startup) {
+    boolean internalCheckTable(EntityDefinition ed, boolean startup) {
+        metaCheckLock.lock()
+        try { return internalCheckTableLocked(ed, startup) }
+        finally { metaCheckLock.unlock() }
+    }
+    private boolean internalCheckTableLocked(EntityDefinition ed, boolean startup) {
         // if it's in this table we've already checked it
         if (entityTablesChecked.containsKey(ed.getFullEntityName())) return false
 
@@ -436,7 +442,12 @@ class EntityDbMeta {
 
         return tableExistsInternal(ed)
     }
-    synchronized boolean tableExistsInternal(EntityDefinition ed) {
+    boolean tableExistsInternal(EntityDefinition ed) {
+        metaCheckLock.lock()
+        try { return tableExistsInternalLocked(ed) }
+        finally { metaCheckLock.unlock() }
+    }
+    private boolean tableExistsInternalLocked(EntityDefinition ed) {
         Boolean exists = entityTablesExist.get(ed.getFullEntityName())
         if (exists != null) return exists.booleanValue()
 

--- a/framework/src/main/groovy/org/moqui/impl/entity/EntityFacadeImpl.groovy
+++ b/framework/src/main/groovy/org/moqui/impl/entity/EntityFacadeImpl.groovy
@@ -50,11 +50,10 @@ import java.sql.*
 import java.util.concurrent.ArrayBlockingQueue
 import java.util.concurrent.BlockingQueue
 import java.util.concurrent.ConcurrentHashMap
-import java.util.concurrent.ThreadFactory
+import java.util.concurrent.ExecutorService
 import java.util.concurrent.ThreadLocalRandom
 import java.util.concurrent.ThreadPoolExecutor
 import java.util.concurrent.TimeUnit
-import java.util.concurrent.atomic.AtomicInteger
 import java.util.concurrent.locks.Lock
 import java.util.concurrent.locks.ReentrantLock
 
@@ -82,6 +81,7 @@ class EntityFacadeImpl implements EntityFacade {
     final Cache<String, long[]> entitySequenceBankCache
     protected final ConcurrentHashMap<String, Lock> dbSequenceLocks = new ConcurrentHashMap<String, Lock>()
     protected final ReentrantLock locationLoadLock = new ReentrantLock()
+    private final ReentrantLock autoReverseLock = new ReentrantLock()
 
     protected HashMap<String, ArrayList<EntityEcaRule>> eecaRulesByEntityName = new HashMap<>()
     protected final HashMap<String, String> entityGroupNameMap = new HashMap<>()
@@ -101,13 +101,8 @@ class EntityFacadeImpl implements EntityFacade {
 
     protected final EntityListImpl emptyList
 
-    private static class ExecThreadFactory implements ThreadFactory {
-        private final ThreadGroup workerGroup = new ThreadGroup("MoquiEntityExec")
-        private final AtomicInteger threadNumber = new AtomicInteger(1)
-        Thread newThread(Runnable r) { return new Thread(workerGroup, r, "MoquiEntityExec-" + threadNumber.getAndIncrement()) }
-    }
-    protected BlockingQueue<Runnable> statementWorkQueue = new ArrayBlockingQueue<>(1024);
-    protected ThreadPoolExecutor statementExecutor = new ThreadPoolExecutor(5, 100, 60, TimeUnit.SECONDS, statementWorkQueue, new ExecThreadFactory());
+    protected BlockingQueue<Runnable> statementWorkQueue = null
+    protected ThreadPoolExecutor statementExecutor = null
 
     EntityFacadeImpl(ExecutionContextFactoryImpl ecfi) {
         this.ecfi = ecfi
@@ -118,6 +113,16 @@ class EntityFacadeImpl implements EntityFacade {
         defaultGroupName = entityFacadeNode.attribute("default-group-name")
         sequencedIdPrefix = entityFacadeNode.attribute("sequenced-id-prefix") ?: null
         queryStats = entityFacadeNode.attribute("query-stats") == "true"
+
+        int stmtQueueSize = (entityFacadeNode.attribute("worker-pool-queue") ?: "1024") as int
+        int stmtPoolCore = (entityFacadeNode.attribute("worker-pool-core") ?: "5") as int
+        int stmtPoolMax = (entityFacadeNode.attribute("worker-pool-max") ?: "100") as int
+        long stmtPoolAlive = (entityFacadeNode.attribute("worker-pool-alive") ?: "60") as long
+        logger.info("Initializing Entity statement worker pool with Virtual Threads (MoquiEntityExec): queue ${stmtQueueSize}, core ${stmtPoolCore}, max ${stmtPoolMax}, alive ${stmtPoolAlive}s")
+        statementWorkQueue = new ArrayBlockingQueue<>(stmtQueueSize)
+        statementExecutor = new ThreadPoolExecutor(stmtPoolCore, stmtPoolMax, stmtPoolAlive, TimeUnit.SECONDS,
+            statementWorkQueue, Thread.ofVirtual().name("MoquiEntityExec-", 1).factory())
+        statementExecutor.allowCoreThreadTimeOut(true)
 
         TimeZone theTimeZone = null
         if (entityFacadeNode.attribute("database-time-zone")) {
@@ -823,7 +828,9 @@ class EntityFacadeImpl implements EntityFacade {
         return ed
     }
 
-    synchronized void createAllAutoReverseManyRelationships() {
+    void createAllAutoReverseManyRelationships() {
+        autoReverseLock.lock()
+        try {
         int relationshipsCreated = 0
         Set<String> entityNameSet = getAllEntityNames()
         for (String entityName in entityNameSet) {
@@ -916,6 +923,9 @@ class EntityFacadeImpl implements EntityFacade {
         }
 
         if (logger.infoEnabled && relationshipsCreated > 0) logger.info("Created ${relationshipsCreated} automatic reverse relationships")
+        } finally {
+            autoReverseLock.unlock()
+        }
     }
 
     // used in tools screen

--- a/framework/src/main/groovy/org/moqui/impl/screen/ScreenFacadeImpl.groovy
+++ b/framework/src/main/groovy/org/moqui/impl/screen/ScreenFacadeImpl.groovy
@@ -29,12 +29,14 @@ import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 
 import javax.cache.Cache
+import java.util.concurrent.locks.ReentrantLock
 
 @CompileStatic
 class ScreenFacadeImpl implements ScreenFacade {
     protected final static Logger logger = LoggerFactory.getLogger(ScreenFacadeImpl.class)
 
     protected final ExecutionContextFactoryImpl ecfi
+    private final ReentrantLock screenDefLock = new ReentrantLock()
 
     protected final Cache<String, ScreenDefinition> screenLocationCache
     protected final Cache<String, ScreenDefinition> screenLocationPermCache
@@ -157,7 +159,12 @@ class ScreenFacadeImpl implements ScreenFacade {
         return makeScreenDefinition(location)
     }
 
-    protected synchronized ScreenDefinition makeScreenDefinition(String location) {
+    protected ScreenDefinition makeScreenDefinition(String location) {
+        screenDefLock.lock()
+        try { return makeScreenDefinitionLocked(location) }
+        finally { screenDefLock.unlock() }
+    }
+    private ScreenDefinition makeScreenDefinitionLocked(String location) {
         ScreenDefinition sd = (ScreenDefinition) screenLocationCache.get(location)
         if (sd != null) return sd
 
@@ -241,7 +248,12 @@ class ScreenFacadeImpl implements ScreenFacade {
         return template
     }
 
-    protected synchronized Template makeTemplateByMode(String renderMode) {
+    protected Template makeTemplateByMode(String renderMode) {
+        screenDefLock.lock()
+        try { return makeTemplateByModeLocked(renderMode) }
+        finally { screenDefLock.unlock() }
+    }
+    private Template makeTemplateByModeLocked(String renderMode) {
         Template template = (Template) screenTemplateModeCache.get(renderMode)
         if (template != null) return template
 
@@ -270,7 +282,12 @@ class ScreenFacadeImpl implements ScreenFacade {
         return makeTemplateByLocation(templateLocation)
     }
 
-    protected synchronized Template makeTemplateByLocation(String templateLocation) {
+    protected Template makeTemplateByLocation(String templateLocation) {
+        screenDefLock.lock()
+        try { return makeTemplateByLocationLocked(templateLocation) }
+        finally { screenDefLock.unlock() }
+    }
+    private Template makeTemplateByLocationLocked(String templateLocation) {
         Template template = (Template) screenTemplateLocationCache.get(templateLocation)
         if (template != null) return template
 
@@ -298,7 +315,12 @@ class ScreenFacadeImpl implements ScreenFacade {
         return makeWidgetTemplatesNodeByLocation(templateLocation)
     }
 
-    protected synchronized MNode makeWidgetTemplatesNodeByLocation(String templateLocation) {
+    protected MNode makeWidgetTemplatesNodeByLocation(String templateLocation) {
+        screenDefLock.lock()
+        try { return makeWidgetTemplatesNodeByLocationLocked(templateLocation) }
+        finally { screenDefLock.unlock() }
+    }
+    private MNode makeWidgetTemplatesNodeByLocationLocked(String templateLocation) {
         MNode templatesNode = (MNode) widgetTemplateLocationCache.get(templateLocation)
         if (templatesNode != null) return templatesNode
 
@@ -318,7 +340,12 @@ class ScreenFacadeImpl implements ScreenFacade {
         if (swr == null) throw new BaseArtifactException("Could not find screen widger renderer for mode ${renderMode}")
         return swr
     }
-    protected synchronized ScreenWidgetRender makeWidgetRenderByMode(String renderMode) {
+    protected ScreenWidgetRender makeWidgetRenderByMode(String renderMode) {
+        screenDefLock.lock()
+        try { return makeWidgetRenderByModeLocked(renderMode) }
+        finally { screenDefLock.unlock() }
+    }
+    private ScreenWidgetRender makeWidgetRenderByModeLocked(String renderMode) {
         ScreenWidgetRender swr = (ScreenWidgetRender) screenWidgetRenderByMode.get(renderMode)
         if (swr != null) return swr
 

--- a/framework/src/main/groovy/org/moqui/impl/screen/ScreenTestImpl.groovy
+++ b/framework/src/main/groovy/org/moqui/impl/screen/ScreenTestImpl.groovy
@@ -190,23 +190,20 @@ class ScreenTestImpl implements ScreenTest {
             ScreenTestRenderImpl stri = this
             Throwable threadThrown = null
 
-            Thread newThread = new Thread("ScreenTestRender") {
-                @Override void run() {
-                    try {
-                        ExecutionContextImpl threadEci = ecfi.getEci()
-                        if (loginSubject != null) threadEci.userFacade.internalLoginSubject(loginSubject)
-                        else if (username != null && !username.isEmpty()) threadEci.userFacade.internalLoginUser(username)
-                        if (authzDisabled) threadEci.artifactExecutionFacade.disableAuthz()
-                        // as this is used for server-side transition calls don't do tarpit checks
-                        threadEci.artifactExecutionFacade.disableTarpit()
-                        renderInternal(threadEci, stri)
-                        threadEci.destroy()
-                    } catch (Throwable t) {
-                        threadThrown = t
-                    }
+            Thread newThread = Thread.ofVirtual().name("ScreenTestRender").start({
+                try {
+                    ExecutionContextImpl threadEci = ecfi.getEci()
+                    if (loginSubject != null) threadEci.userFacade.internalLoginSubject(loginSubject)
+                    else if (username != null && !username.isEmpty()) threadEci.userFacade.internalLoginUser(username)
+                    if (authzDisabled) threadEci.artifactExecutionFacade.disableAuthz()
+                    // as this is used for server-side transition calls don't do tarpit checks
+                    threadEci.artifactExecutionFacade.disableTarpit()
+                    renderInternal(threadEci, stri)
+                    threadEci.destroy()
+                } catch (Throwable t) {
+                    threadThrown = t
                 }
-            }
-            newThread.start()
+            })
             newThread.join()
             if (threadThrown != null) throw threadThrown
             return this

--- a/framework/src/main/groovy/org/moqui/impl/service/ScheduledJobRunner.groovy
+++ b/framework/src/main/groovy/org/moqui/impl/service/ScheduledJobRunner.groovy
@@ -74,7 +74,7 @@ class ScheduledJobRunner implements Runnable {
     int getLastJobsPaused() { lastJobsPaused }
 
     @Override
-    synchronized void run() {
+    void run() {
         try {
             runInternal()
         } catch (Throwable t) {
@@ -91,7 +91,7 @@ class ScheduledJobRunner implements Runnable {
         ExecutionContextImpl eci = ecfi.getEci()
         eci.artifactExecution.disableAuthz()
         EntityFacadeImpl efi = ecfi.entityFacade
-        ThreadPoolExecutor jobWorkerPool = ecfi.serviceFacade.jobWorkerPool
+        ThreadPoolExecutor jobWorkerPool = (ThreadPoolExecutor) ecfi.serviceFacade.jobWorkerPool
         try {
             // make sure no transaction is in place, shouldn't be any so try to commit if there is one
             if (ecfi.transactionFacade.isTransactionInPlace()) {

--- a/framework/src/main/groovy/org/moqui/impl/service/ServiceFacadeImpl.groovy
+++ b/framework/src/main/groovy/org/moqui/impl/service/ServiceFacadeImpl.groovy
@@ -102,8 +102,8 @@ class ServiceFacadeImpl implements ServiceFacade {
         logger.info("Initializing Service Job ThreadPoolExecutor: queue limit ${jobQueueMax}, pool-core ${coreSize}, pool-max ${maxSize}, pool-alive ${aliveTime}s")
         // make the actual queue at least maxSize to allow for stuffing the queue to get it to add threads to the pool
         BlockingQueue<Runnable> workQueue = new LinkedBlockingQueue<>(jobQueueMax < maxSize ? maxSize : jobQueueMax)
-        return new ContextJavaUtil.WorkerThreadPoolExecutor(ecfi, coreSize, maxSize, aliveTime, TimeUnit.SECONDS,
-                workQueue, new ContextJavaUtil.JobThreadFactory())
+        return new ContextJavaUtil.VirtualThreadExecutorService(ecfi, "MoquiJob", coreSize, maxSize, aliveTime, TimeUnit.SECONDS,
+                workQueue)
     }
 
     void postFacadeInit() {

--- a/framework/src/main/groovy/org/moqui/impl/webapp/ElasticRequestLogFilter.groovy
+++ b/framework/src/main/groovy/org/moqui/impl/webapp/ElasticRequestLogFilter.groovy
@@ -27,6 +27,7 @@ import jakarta.servlet.http.HttpServletResponse
 import jakarta.servlet.http.HttpServletResponseWrapper
 import jakarta.servlet.http.HttpSession
 import java.util.concurrent.ConcurrentLinkedQueue
+import java.util.concurrent.locks.ReentrantLock
 
 /** Save data about HTTP requests to ElasticSearch using a Servlet Filter */
 @CompileStatic
@@ -169,7 +170,7 @@ class ElasticRequestLogFilter implements Filter {
 
         RequestLogQueueFlush(ElasticRequestLogFilter filter) { this.filter = filter }
 
-        @Override synchronized void run() {
+        @Override void run() {
             while (filter.requestLogQueue.size() > 0) { flushQueue() }
         }
         void flushQueue() {
@@ -224,23 +225,30 @@ class ElasticRequestLogFilter implements Filter {
     class CountingHttpServletResponseWrapper extends HttpServletResponseWrapper {
         private OutputStreamCounter outputStream = null;
         private PrintWriter writer = null;
+        private final ReentrantLock streamLock = new ReentrantLock();
 
         CountingHttpServletResponseWrapper(HttpServletResponse response) throws IOException { super(response); }
         long getWritten() { return outputStream != null ? outputStream.getWritten() : 0; }
 
-        @Override synchronized ServletOutputStream getOutputStream() throws IOException {
-            if (writer != null) throw new IllegalStateException("getWriter() already called");
-            if (outputStream == null) outputStream = new OutputStreamCounter(super.getOutputStream());
-            return outputStream;
+        @Override ServletOutputStream getOutputStream() throws IOException {
+            streamLock.lock()
+            try {
+                if (writer != null) throw new IllegalStateException("getWriter() already called");
+                if (outputStream == null) outputStream = new OutputStreamCounter(super.getOutputStream());
+                return outputStream;
+            } finally { streamLock.unlock() }
         }
 
-        @Override synchronized PrintWriter getWriter() throws IOException {
-            if (writer == null && outputStream != null) throw new IllegalStateException("getOutputStream() already called");
-            if (writer == null) {
-                outputStream = new OutputStreamCounter(super.getOutputStream());
-                writer = new PrintWriter(new OutputStreamWriter(outputStream, getCharacterEncoding()));
-            }
-            return this.writer;
+        @Override PrintWriter getWriter() throws IOException {
+            streamLock.lock()
+            try {
+                if (writer == null && outputStream != null) throw new IllegalStateException("getOutputStream() already called");
+                if (writer == null) {
+                    outputStream = new OutputStreamCounter(super.getOutputStream());
+                    writer = new PrintWriter(new OutputStreamWriter(outputStream, getCharacterEncoding()));
+                }
+                return this.writer;
+            } finally { streamLock.unlock() }
         }
 
         @Override void flushBuffer() throws IOException {

--- a/framework/src/main/java/org/moqui/jcache/MCache.java
+++ b/framework/src/main/java/org/moqui/jcache/MCache.java
@@ -30,6 +30,7 @@ import javax.cache.processor.EntryProcessorResult;
 import java.util.*;
 import java.util.concurrent.*;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.locks.ReentrantLock;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -50,6 +51,7 @@ public class MCache<K, V> implements Cache<K, V> {
 
     private MStats stats = new MStats();
     private boolean statsEnabled = true;
+    private final ReentrantLock maxEntriesLock = new ReentrantLock();
 
     private Duration accessDuration = null;
     private Duration creationDuration = null;
@@ -106,23 +108,26 @@ public class MCache<K, V> implements Cache<K, V> {
         hasExpiry = accessDuration != null || creationDuration != null || updateDuration != null;
     }
 
-    public synchronized void setMaxEntries(int elements) {
-        if (elements == 0) {
-            if (evictRunnable != null) {
-                evictRunnable = null;
-                evictFuture.cancel(false);
-                evictFuture = null;
-            }
-        } else {
-            if (evictRunnable != null) {
-                evictRunnable.maxEntries = elements;
+    public void setMaxEntries(int elements) {
+        maxEntriesLock.lock();
+        try {
+            if (elements == 0) {
+                if (evictRunnable != null) {
+                    evictRunnable = null;
+                    evictFuture.cancel(false);
+                    evictFuture = null;
+                }
             } else {
-                evictRunnable = new EvictRunnable(this, elements);
-                long maxCheckSeconds = 30;
-                if (configuration instanceof MCacheConfiguration) maxCheckSeconds = ((MCacheConfiguration) configuration).maxCheckSeconds;
-                evictFuture = workerPool.scheduleWithFixedDelay(evictRunnable, 1, maxCheckSeconds, TimeUnit.SECONDS);
+                if (evictRunnable != null) {
+                    evictRunnable.maxEntries = elements;
+                } else {
+                    evictRunnable = new EvictRunnable(this, elements);
+                    long maxCheckSeconds = 30;
+                    if (configuration instanceof MCacheConfiguration) maxCheckSeconds = ((MCacheConfiguration) configuration).maxCheckSeconds;
+                    evictFuture = workerPool.scheduleWithFixedDelay(evictRunnable, 1, maxCheckSeconds, TimeUnit.SECONDS);
+                }
             }
-        }
+        } finally { maxEntriesLock.unlock(); }
     }
     public int getMaxEntries() { return evictRunnable != null ? evictRunnable.maxEntries : 0; }
 

--- a/framework/src/main/java/org/moqui/jcache/MCacheManager.java
+++ b/framework/src/main/java/org/moqui/jcache/MCacheManager.java
@@ -25,6 +25,7 @@ import java.net.URISyntaxException;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Properties;
+import java.util.concurrent.locks.ReentrantLock;
 
 /** This class does not completely support the javax.cache.CacheManager spec, it is just enough to use as a factory for MCache instances. */
 public class MCacheManager implements CacheManager {
@@ -38,6 +39,7 @@ public class MCacheManager implements CacheManager {
     private Properties props = new Properties();
     private Map<String, MCache> cacheMap = new LinkedHashMap<>();
     private boolean isClosed = false;
+    private final ReentrantLock createCacheLock = new ReentrantLock();
 
     private MCacheManager() {
         try { cmUri = new URI("MCacheManager"); }
@@ -56,16 +58,19 @@ public class MCacheManager implements CacheManager {
 
     @Override
     @SuppressWarnings("unchecked")
-    public synchronized <K, V, C extends Configuration<K, V>> Cache<K, V> createCache(String cacheName, C configuration) throws IllegalArgumentException {
-        if (isClosed) throw new IllegalStateException("MCacheManager is closed");
-        if (cacheMap.containsKey(cacheName)) {
-            // not per spec, but be more friendly and just return the existing cache: throw new CacheException("Cache with name " + cacheName + " already exists");
-            return cacheMap.get(cacheName);
-        }
+    public <K, V, C extends Configuration<K, V>> Cache<K, V> createCache(String cacheName, C configuration) throws IllegalArgumentException {
+        createCacheLock.lock();
+        try {
+            if (isClosed) throw new IllegalStateException("MCacheManager is closed");
+            if (cacheMap.containsKey(cacheName)) {
+                // not per spec, but be more friendly and just return the existing cache: throw new CacheException("Cache with name " + cacheName + " already exists");
+                return cacheMap.get(cacheName);
+            }
 
-        MCache<K, V> newCache = new MCache(cacheName, this, configuration);
-        cacheMap.put(cacheName, newCache);
-        return newCache;
+            MCache<K, V> newCache = new MCache(cacheName, this, configuration);
+            cacheMap.put(cacheName, newCache);
+            return newCache;
+        } finally { createCacheLock.unlock(); }
     }
 
     @Override

--- a/framework/src/main/java/org/moqui/jcache/MEntry.java
+++ b/framework/src/main/java/org/moqui/jcache/MEntry.java
@@ -16,10 +16,12 @@ package org.moqui.jcache;
 import javax.cache.Cache;
 import javax.cache.expiry.Duration;
 import javax.cache.expiry.ExpiryPolicy;
+import java.util.concurrent.locks.ReentrantLock;
 
 public class MEntry<K, V> implements Cache.Entry<K, V> {
     private static final Class<MEntry> thisClass = MEntry.class;
     private final K key;
+    private final ReentrantLock valueLock = new ReentrantLock();
     V value;
     private long createdTime = 0;
     long lastUpdatedTime = 0;
@@ -71,16 +73,18 @@ public class MEntry<K, V> implements Cache.Entry<K, V> {
     }
 
     void setValue(V val, long updateTime) {
-        synchronized (key) {
+        valueLock.lock();
+        try {
             if (updateTime > lastUpdatedTime) {
                 value = val;
                 lastUpdatedTime = updateTime;
             }
-        }
+        } finally { valueLock.unlock(); }
     }
 
     boolean setValueIfEquals(V oldVal, V val, long updateTime) {
-        synchronized (key) {
+        valueLock.lock();
+        try {
             if (updateTime > lastUpdatedTime && valueEquals(oldVal)) {
                 value = val;
                 lastUpdatedTime = updateTime;
@@ -88,7 +92,7 @@ public class MEntry<K, V> implements Cache.Entry<K, V> {
             } else {
                 return false;
             }
-        }
+        } finally { valueLock.unlock(); }
     }
 
     public long getCreatedTime() {

--- a/framework/src/main/java/org/moqui/util/MClassLoader.java
+++ b/framework/src/main/java/org/moqui/util/MClassLoader.java
@@ -15,6 +15,7 @@ package org.moqui.util;
 
 import java.io.*;
 import java.net.MalformedURLException;
+import java.net.URI;
 import java.net.URL;
 import java.security.CodeSource;
 import java.security.ProtectionDomain;
@@ -243,10 +244,10 @@ public class MClassLoader extends ClassLoader {
                 JarEntry jarEntry = jarFile.getJarEntry(resourceName);
                 if (jarEntry != null) {
                     try {
-                        String jarFileName = jarFile.getName();
-                        if (jarFileName.contains("\\")) jarFileName = jarFileName.replace('\\', '/');
-                        resourceUrl = new URL("jar:file:" + jarFileName + "!/" + jarEntry);
-                    } catch (MalformedURLException e) {
+                        File jf = new File(jarFile.getName());
+                        URI jarUri = new URI("jar", jf.toURI().toString() + "!/" + jarEntry, null);
+                        resourceUrl = jarUri.toURL();
+                    } catch (Exception e) {
                         System.out.println("Error making URL for [" + resourceName + "] in jar [" + jarFile + "]: " + e.toString());
                     }
                 }
@@ -312,10 +313,10 @@ public class MClassLoader extends ClassLoader {
             JarEntry jarEntry = jarFile.getJarEntry(resourceName);
             if (jarEntry != null) {
                 try {
-                    String jarFileName = jarFile.getName();
-                    if (jarFileName.contains("\\")) jarFileName = jarFileName.replace('\\', '/');
-                    urlList.add(new URL("jar:file:" + jarFileName + "!/" + jarEntry));
-                } catch (MalformedURLException e) {
+                    File jf = new File(jarFile.getName());
+                    URI jarUri = new URI("jar", jf.toURI().toString() + "!/" + jarEntry, null);
+                    urlList.add(jarUri.toURL());
+                } catch (Exception e) {
                     System.out.println("Error making URL for [" + resourceName + "] in jar [" + jarFile + "]: " + e.toString());
                 }
             }

--- a/framework/src/main/java/org/moqui/util/MNode.java
+++ b/framework/src/main/java/org/moqui/util/MNode.java
@@ -35,6 +35,7 @@ import java.io.*;
 import java.nio.file.Files;
 import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.locks.ReentrantLock;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 
@@ -890,7 +891,8 @@ public class MNode implements TemplateNodeModel, TemplateSequenceModel, Template
     private static final BeansWrapper wrapper = new BeansWrapperBuilder(FTL_VERSION).build();
     private static final FtlNodeListWrapper emptyNodeListWrapper = new FtlNodeListWrapper(new ArrayList<>(), null);
     private FtlNodeListWrapper allChildren = null;
-    private ConcurrentHashMap<String, TemplateModel> ftlAttrAndChildren = null;
+    private volatile ConcurrentHashMap<String, TemplateModel> ftlAttrAndChildren = null;
+    private final ReentrantLock ftlAttrAndChildrenLock = new ReentrantLock();
     private ConcurrentHashMap<String, Boolean> knownNullAttributes = null;
 
     public Object getAdaptedObject(Class aClass) { return this; }
@@ -937,9 +939,12 @@ public class MNode implements TemplateNodeModel, TemplateSequenceModel, Template
             }
         }
     }
-    private synchronized ConcurrentHashMap<String, TemplateModel> makeAttrAndChildrenByName() {
-        if (ftlAttrAndChildren == null) ftlAttrAndChildren = new ConcurrentHashMap<>();
-        return ftlAttrAndChildren;
+    private ConcurrentHashMap<String, TemplateModel> makeAttrAndChildrenByName() {
+        ftlAttrAndChildrenLock.lock();
+        try {
+            if (ftlAttrAndChildren == null) ftlAttrAndChildren = new ConcurrentHashMap<>();
+            return ftlAttrAndChildren;
+        } finally { ftlAttrAndChildrenLock.unlock(); }
     }
     @Override public boolean isEmpty() {
         return attributeMap.isEmpty() && (childList == null || childList.isEmpty()) && (childText == null || childText.length() == 0);

--- a/framework/src/test/groovy/VirtualThreadMoquiSuite.groovy
+++ b/framework/src/test/groovy/VirtualThreadMoquiSuite.groovy
@@ -1,0 +1,27 @@
+/*
+ * This software is in the public domain under CC0 1.0 Universal plus a
+ * Grant of Patent License.
+ *
+ * To the extent possible under law, the author(s) have dedicated all
+ * copyright and related and neighboring rights to this software to the
+ * public domain worldwide. This software is distributed without any
+ * warranty.
+ *
+ * You should have received a copy of the CC0 Public Domain Dedication
+ * along with this software (see the LICENSE.md file). If not, see
+ * <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+
+import org.junit.jupiter.api.AfterAll
+import org.junit.platform.suite.api.SelectClasses
+import org.junit.platform.suite.api.Suite
+import org.moqui.Moqui
+
+@Suite
+@SelectClasses([VirtualThreadStressTests.class])
+class VirtualThreadMoquiSuite {
+    @AfterAll
+    static void destroyMoqui() {
+        Moqui.destroyActiveExecutionContextFactory()
+    }
+}

--- a/framework/src/test/groovy/VirtualThreadStressTests.groovy
+++ b/framework/src/test/groovy/VirtualThreadStressTests.groovy
@@ -1,0 +1,244 @@
+/*
+ * This software is in the public domain under CC0 1.0 Universal plus a
+ * Grant of Patent License.
+ *
+ * To the extent possible under law, the author(s) have dedicated all
+ * copyright and related and neighboring rights to this software to the
+ * public domain worldwide. This software is distributed without any
+ * warranty.
+ *
+ * You should have received a copy of the CC0 Public Domain Dedication
+ * along with this software (see the LICENSE.md file). If not, see
+ * <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+
+import org.moqui.Moqui
+import org.moqui.context.ExecutionContext
+import org.moqui.impl.context.ExecutionContextFactoryImpl
+import org.moqui.impl.service.ServiceFacadeImpl
+import spock.lang.Shared
+import spock.lang.Specification
+import spock.lang.Timeout
+
+import java.lang.reflect.Field
+import java.util.concurrent.Callable
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.Future
+import java.util.concurrent.ThreadPoolExecutor
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicInteger
+
+@Timeout(180)
+class VirtualThreadStressTests extends Specification {
+    @Shared ExecutionContext ec
+    @Shared ExecutionContextFactoryImpl ecfi
+    @Shared ServiceFacadeImpl sfi
+    @Shared ThreadPoolExecutor workerPool
+    @Shared ThreadPoolExecutor jobWorkerPool
+    @Shared ThreadPoolExecutor entityStatementExecutor
+
+    def setupSpec() {
+        ecfi = (ExecutionContextFactoryImpl) Moqui.getExecutionContextFactory()
+        ec = Moqui.getExecutionContext()
+        sfi = ecfi.serviceFacade
+        workerPool = (ThreadPoolExecutor) ecfi.workerPool
+        jobWorkerPool = (ThreadPoolExecutor) sfi.jobWorkerPool
+        entityStatementExecutor = getField(ecfi.entityFacade, "statementExecutor", ThreadPoolExecutor)
+    }
+
+    def cleanupSpec() {
+        if (ec != null) ec.destroy()
+    }
+
+    def setup() {
+        ec.artifactExecution.disableAuthz()
+        ec.message.clearAll()
+    }
+
+    def cleanup() {
+        try {
+            ec.message.clearAll()
+        } finally {
+            ec.artifactExecution.enableAuthz()
+        }
+
+        assert ecfi.waitWorkerPoolEmpty(120)
+        assert waitExecutorIdle(workerPool, 120)
+        assert waitExecutorIdle(jobWorkerPool, 120)
+        assert waitExecutorIdle(entityStatementExecutor, 120)
+    }
+
+    def "worker pool runs burst load on virtual threads"() {
+        given:
+        int taskCount = Math.max(workerPool.corePoolSize * 4, 48)
+
+        when:
+        Map burst = runBurst(workerPool, taskCount) { int taskNumber ->
+            ExecutionContext localEc = Moqui.getExecutionContext()
+            try {
+                localEc.artifactExecution.disableAuthz()
+                long enumCount = localEc.entity.find("moqui.basic.Enumeration")
+                    .useCache(false).count()
+                Thread.sleep(120)
+                return [taskNumber: taskNumber, virtual: Thread.currentThread().isVirtual(),
+                    name: Thread.currentThread().getName(), enumCount: enumCount]
+            } finally {
+                localEc.artifactExecution.enableAuthz()
+                localEc.destroy()
+            }
+        }
+
+        then:
+        !ec.message.hasError()
+        burst.results.size() == taskCount
+        burst.results.every { ((Boolean) it.virtual) }
+        burst.results.every { ((String) it.name).startsWith("MoquiWorker-") }
+        burst.results.every { ((Number) it.enumCount).longValue() >= 0L }
+        burst.maxRunning >= minimumExpectedConcurrency(workerPool.corePoolSize)
+    }
+
+    def "async services complete cleanly under worker pool load"() {
+        given:
+        int taskCount = Math.max(workerPool.corePoolSize * 4, 64)
+        List<Future<Map<String, Object>>> futures = []
+
+        when:
+        for (int i = 0; i < taskCount; i++) {
+            futures.add(ec.service.async()
+                .name("org.moqui.impl.ServerServices.get#VisitClientIpData")
+                .parameters([visitId: "VT_ASYNC_${i}".toString()])
+                .callFuture())
+        }
+        List<Map<String, Object>> results = futures.collect {
+            (Map<String, Object>) it.get(60, TimeUnit.SECONDS)
+        }
+
+        then:
+        !ec.message.hasError()
+        results.size() == taskCount
+        results.every { it instanceof Map }
+        ecfi.waitWorkerPoolEmpty(120)
+    }
+
+    def "service job pool scales past core size on virtual threads"() {
+        given:
+        int queueCapacity = jobWorkerPool.queue.size() + jobWorkerPool.queue.remainingCapacity()
+        int taskCount = Math.max(queueCapacity + jobWorkerPool.maximumPoolSize - 1, 32)
+
+        when:
+        Map burst = runBurst(jobWorkerPool, taskCount) { int taskNumber ->
+            ExecutionContext localEc = Moqui.getExecutionContext()
+            try {
+                localEc.artifactExecution.disableAuthz()
+                Map result = localEc.service.sync()
+                    .name("org.moqui.impl.ServerServices.get#VisitClientIpData")
+                    .parameters([visitId: "VT_JOB_${taskNumber}".toString()])
+                    .call()
+                Thread.sleep(160)
+                return [taskNumber: taskNumber, virtual: Thread.currentThread().isVirtual(),
+                    name: Thread.currentThread().getName(), resultMap: result]
+            } finally {
+                localEc.artifactExecution.enableAuthz()
+                localEc.destroy()
+            }
+        }
+
+        then:
+        !ec.message.hasError()
+        burst.results.size() == taskCount
+        burst.results.every { ((Boolean) it.virtual) }
+        burst.results.every { ((String) it.name).startsWith("MoquiJob-") }
+        burst.results.every { it.resultMap instanceof Map }
+        if (jobWorkerPool.maximumPoolSize > jobWorkerPool.corePoolSize) {
+            assert burst.maxRunning > jobWorkerPool.corePoolSize
+        } else {
+            assert burst.maxRunning >= jobWorkerPool.corePoolSize
+        }
+    }
+
+    def "entity statement pool handles burst load on virtual threads"() {
+        given:
+        int taskCount = Math.max(entityStatementExecutor.corePoolSize * 6, 30)
+
+        when:
+        Map burst = runBurst(entityStatementExecutor, taskCount) { int taskNumber ->
+            ExecutionContext localEc = Moqui.getExecutionContext()
+            boolean beganTx = false
+            try {
+                localEc.artifactExecution.disableAuthz()
+                beganTx = localEc.transaction.begin(60)
+                long enumCount = localEc.entity.find("moqui.basic.Enumeration")
+                    .useCache(false).count()
+                Thread.sleep(120)
+                return [taskNumber: taskNumber, virtual: Thread.currentThread().isVirtual(),
+                    name: Thread.currentThread().getName(), enumCount: enumCount]
+            } finally {
+                localEc.transaction.commit(beganTx)
+                localEc.artifactExecution.enableAuthz()
+                localEc.destroy()
+            }
+        }
+
+        then:
+        !ec.message.hasError()
+        burst.results.size() == taskCount
+        burst.results.every { ((Boolean) it.virtual) }
+        burst.results.every { ((String) it.name).startsWith("MoquiEntityExec-") }
+        burst.results.every { ((Number) it.enumCount).longValue() >= 0L }
+        burst.maxRunning >= minimumExpectedConcurrency(entityStatementExecutor.corePoolSize)
+    }
+
+    private static Map runBurst(ThreadPoolExecutor executor, int taskCount, Closure<Map> work) {
+        CountDownLatch startLatch = new CountDownLatch(1)
+        AtomicInteger runningNow = new AtomicInteger(0)
+        AtomicInteger maxRunning = new AtomicInteger(0)
+        List<Future<Map>> futures = new ArrayList<>(taskCount)
+
+        try {
+            for (int i = 0; i < taskCount; i++) {
+                final int taskNumber = i
+                futures.add(executor.submit({
+                    assert startLatch.await(15, TimeUnit.SECONDS)
+                    int current = runningNow.incrementAndGet()
+                    updateMax(maxRunning, current)
+                    try {
+                        return work.call(taskNumber)
+                    } finally {
+                        runningNow.decrementAndGet()
+                    }
+                } as Callable<Map>))
+            }
+        } finally {
+            startLatch.countDown()
+        }
+        List<Map> results = futures.collect { Future<Map> future -> future.get(90, TimeUnit.SECONDS) }
+        return [results: results, maxRunning: maxRunning.get()]
+    }
+
+    private static void updateMax(AtomicInteger currentMax, int candidate) {
+        while (true) {
+            int previous = currentMax.get()
+            if (candidate <= previous) return
+            if (currentMax.compareAndSet(previous, candidate)) return
+        }
+    }
+
+    private static int minimumExpectedConcurrency(int corePoolSize) {
+        return Math.max(2, Math.min(corePoolSize, 6))
+    }
+
+    private static boolean waitExecutorIdle(ThreadPoolExecutor executor, int retryLimit) {
+        int count = 0
+        while (count < retryLimit && (executor.activeCount > 0 || executor.queue.size() > 0)) {
+            Thread.sleep(100)
+            count++
+        }
+        return executor.activeCount == 0 && executor.queue.size() == 0
+    }
+
+    private static <T> T getField(Object target, String fieldName, Class<T> type) {
+        Field field = target.getClass().getDeclaredField(fieldName)
+        field.setAccessible(true)
+        return type.cast(field.get(target))
+    }
+}


### PR DESCRIPTION
## Summary

This PR makes the framework compatible with Java 21 virtual threads by eliminating carrier-thread pinning caused by `synchronized` blocks.

### Changes

- Replaces all `synchronized` methods and blocks with `ReentrantLock` throughout the framework (ExecutionContextFactoryImpl, EntityFacadeImpl, ServiceFacadeImpl, CacheFacadeImpl, and others)
- Introduces `VirtualThreadExecutorService` — a thin wrapper over `Executors.newVirtualThreadPerTaskExecutor()` wired into the service facade
- Adds `VirtualThreadMoquiSuite` and `VirtualThreadStressTests` to verify correctness and throughput under concurrent virtual-thread load

### Why

Java 21 virtual threads are pinned to their carrier OS thread whenever they block inside a `synchronized` block or method. On a busy Moqui instance this causes carrier starvation, negating the benefits of virtual threads. Using `ReentrantLock` releases the carrier on block, allowing the JVM to schedule other virtual threads freely.

### Test results

`VirtualThreadStressTests` (4 tests) all pass. Existing test suite unaffected.