### PR TITLE
Add optional Python/JEP support to simple Docker image

### DIFF
--- a/docker/simple/Dockerfile
+++ b/docker/simple/Dockerfile
@@ -6,8 +6,8 @@ MAINTAINER Moqui Framework <moqui@googlegroups.com>
 
 WORKDIR /opt/moqui
 
-# for running from the war directly, preffered approach unzips war in advance (see docker-build.sh that does this)
-#COPY moqui.war .
+# for running from the war directly, preferred approach unzips war in advance (see docker-build.sh that does this)
+# COPY moqui.war .
 # copy files from unzipped moqui.war file
 COPY WEB-INF WEB-INF
 COPY META-INF META-INF
@@ -16,6 +16,31 @@ COPY execlib execlib
 
 # always want the runtime directory
 COPY runtime runtime
+RUN find /opt/moqui/runtime -type d \( -name 'python_venv' -o -name 'venv' -o -name '.venv' \) -prune -exec rm -rf {} +
+
+# curl and ca-certificates are always needed (HEALTHCHECK + HTTPS calls)
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends curl ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+
+# Optional: Python + JEP (Java Embedded Python) support.
+# Enabled automatically when the moqui-jep component is present in the build
+# (docker-build.sh detects runtime/component/moqui-jep and passes WITH_JEP=true).
+# Can also be forced manually: docker build --build-arg WITH_JEP=true ...
+ARG WITH_JEP=false
+RUN if [ "$WITH_JEP" = "true" ]; then \
+      apt-get update \
+      && apt-get install -y --no-install-recommends \
+         python3 python3-venv python3-pip python3-dev build-essential \
+      && rm -rf /var/lib/apt/lists/* \
+      && python3 -m venv /opt/moqui/runtime/python_venv \
+      && /opt/moqui/runtime/python_venv/bin/python -m pip install --upgrade pip \
+      && /opt/moqui/runtime/python_venv/bin/pip install --no-cache-dir numpy \
+      && /opt/moqui/runtime/python_venv/bin/pip install --no-cache-dir jep==4.2.2; \
+    fi
+
+ENV PYTHONNOUSERSITE=1
+ENV PYTHONPATH=
 
 # create user for search and chown corresponding files
 ARG search_name=opensearch
@@ -47,10 +72,11 @@ EXPOSE 9300
 # Hazelcast Cluster Port
 EXPOSE 5701
 
-# this is to run from the war file directly, preferred approach unzips war file in advance
-# ENTRYPOINT ["java", "-jar", "moqui.war"]
-ENTRYPOINT ["java", "-cp", ".", "MoquiStart"]
+# Copy the entrypoint script
+COPY docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
+RUN chmod +x /usr/local/bin/docker-entrypoint.sh
+ENTRYPOINT ["/usr/local/bin/docker-entrypoint.sh"]
 
-HEALTHCHECK --interval=30s --timeout=600ms --start-period=120s CMD curl -f -H "X-Forwarded-Proto: https" -H "X-Forwarded-Ssl: on" http://localhost/status || exit 1
+HEALTHCHECK --interval=30s --timeout=2s --start-period=120s CMD curl -f -H "X-Forwarded-Proto: https" -H "X-Forwarded-Ssl: on" http://localhost/status || exit 1
 # specify this as a default parameter if none are specified with docker exec/run, ie run production by default
 CMD ["conf=conf/MoquiProductionConf.xml", "port=80"]

--- a/docker/simple/docker-build.sh
+++ b/docker/simple/docker-build.sh
@@ -32,7 +32,17 @@ else
     exit 1
 fi
 
-docker build -t $NAME_TAG --build-arg RUNTIME_IMAGE=$RUNTIME_IMAGE .
+# delete test Python venvs from the copied runtime
+rm -rf runtime/python_venv runtime/**/venv runtime/**/.venv
+
+# Auto-detect moqui-jep component: if present, enable Python/JEP in the image
+WITH_JEP=false
+if [ -d runtime/component/moqui-jep ]; then
+  echo "moqui-jep component detected: Python/JEP support will be included in the image"
+  WITH_JEP=true
+fi
+
+docker build -t $NAME_TAG --build-arg RUNTIME_IMAGE=$RUNTIME_IMAGE --build-arg WITH_JEP=$WITH_JEP .
 
 if [ -d META-INF ]; then rm -Rf META-INF; fi
 if [ -d WEB-INF ]; then rm -Rf WEB-INF; fi

--- a/docker/simple/docker-entrypoint.sh
+++ b/docker/simple/docker-entrypoint.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env sh
+set -e
+
+MOQUI_HOME="${MOQUI_HOME:-/opt/moqui}"
+VENV_DIR="${VENV_DIR:-$MOQUI_HOME/runtime/python_venv}"
+PORT="${PORT:-80}"
+
+PYBIN="$VENV_DIR/bin/python"
+
+if [ -x "$PYBIN" ]; then
+    # JEP mode: resolve libjep.so from the venv and configure JVM flags
+    unset PYTHONPATH
+    export PYTHONNOUSERSITE=1
+
+    read -r JEP_LIB SITE_PKGS <<EOF
+$("$PYBIN" - <<'PY'
+import sysconfig, os
+site = sysconfig.get_paths().get('purelib') or ''
+lib  = os.path.join(site, 'jep', 'libjep.so')
+print((lib if os.path.isfile(lib) else '') + ' ' + site)
+PY
+)
+EOF
+
+    if [ -f "$JEP_LIB" ]; then
+        export LD_LIBRARY_PATH="$(dirname "$JEP_LIB")${LD_LIBRARY_PATH:+:}$LD_LIBRARY_PATH"
+        exec java -Djep.lib="$JEP_LIB" -Djep_site_pkgs="$SITE_PKGS" -cp . MoquiStart "port=$PORT" "$@"
+    else
+        echo "WARN: Python venv found but libjep.so not found at $JEP_LIB, starting without JEP" >&2
+    fi
+fi
+
+# Standard start — no JEP venv present or libjep.so not found
+exec java -cp . MoquiStart "port=$PORT" "$@"


### PR DESCRIPTION
### Summary
This PR adds optional Python and JEP (Java Embedded Python) support to the simple Docker image build. The build is completely opt-in and auto-detected, introducing zero modifications to the core framework's `build.gradle`.

All opinionated Swarm/stack deployment configurations from the previous PR attempt have been removed, as they will be moved to a separate `moqui-deploy` component.

### Changes
1. **Dockerfile**: Added a `WITH_JEP` build argument (default `false`). When `true`, it installs Python 3 dependencies, creates a virtual environment inside the runtime directory, and pre-installs `numpy` and `jep`.
2. **docker-build.sh**: Auto-detects if the `moqui-jep` component is present under `runtime/component/`. If detected, it automatically passes `--build-arg WITH_JEP=true` to the build command.
3. **docker-entrypoint.sh**: Added a custom entrypoint script that dynamically resolves the location of the JEP native library (`libjep.so`) inside the virtualenv and starts the JVM with the required `-Djep.lib` and `-Djep_site_pkgs` system properties.

This keeps all JEP configurations completely isolated inside the `moqui-jep` component and ensures the Docker build remains clean and standard when JEP is not in use.