### PR TITLE
Make Jetty HTTP client compliance configurable via system property

### DIFF
--- a/framework/src/main/java/org/moqui/util/RestClient.java
+++ b/framework/src/main/java/org/moqui/util/RestClient.java
@@ -54,6 +54,7 @@ import org.eclipse.jetty.client.StringRequestContent;
 import org.eclipse.jetty.client.ValidatingConnectionPool;
 import org.eclipse.jetty.client.transport.HttpClientTransportDynamic;
 import org.eclipse.jetty.client.transport.HttpClientTransportOverHTTP;
+import org.eclipse.jetty.http.HttpCompliance;
 import org.eclipse.jetty.http.HttpCookieStore;
 import org.eclipse.jetty.http.HttpField;
 import org.eclipse.jetty.http.HttpFields;
@@ -725,6 +726,10 @@ public class RestClient {
             if (disableCookieManagement) httpClient.setHttpCookieStore(new HttpCookieStore.Empty());
             // use a default idle timeout of 15 seconds, should be lower than server idle timeouts which will vary by server but 30 seconds seems to be common
             httpClient.setIdleTimeout(15000);
+            // Allow HTTP compliance to be tuned without code changes.
+            // Example: -Dmoqui.http.client.compliance=RFC7230 to accept BAD_QUOTES_IN_TOKEN in responses (e.g. Shopify).
+            String complianceProp = System.getProperty("moqui.http.client.compliance");
+            if (complianceProp != null && !complianceProp.isEmpty()) httpClient.setHttpCompliance(HttpCompliance.valueOf(complianceProp));
             try { httpClient.start(); } catch (Exception e) { throw new BaseException("Error starting HTTP client", e); }
         }
 


### PR DESCRIPTION
  Jetty 12's HttpClient defaults to HttpCompliance.RFC9110, which strictly
  rejects response headers containing quoted characters in token positions
  (BAD_QUOTES_IN_TOKEN). Some external APIs such as Shopify return Set-Cookie
  response headers that violate this rule, causing RestClient to throw a
  BaseException and fail the request even though credentials and payload are valid.

  Added support for a JVM system property moqui.http.client.compliance that
  is read once when SimpleRequestFactory initializes the shared HttpClient.
  When set, the specified compliance mode is applied to the HttpClient before
  it starts, making the behavior configurable without code changes.

  To allow BAD_QUOTES_IN_TOKEN violations (e.g. for Shopify):
    -Dmoqui.http.client.compliance=RFC7230

  Valid values: RFC9110 (Jetty default), RFC7230, RFC2616, RFC2616_LEGACY,
  LEGACY, STRICT