### PR TITLE
Add Dashboard entity and dashboard type metadata

### DIFF
--- a/framework/data/MoquiSetupData.xml
+++ b/framework/data/MoquiSetupData.xml
@@ -120,6 +120,9 @@ along with this software (see the LICENSE.md file). If not, see
     <moqui.security.UserPermission userPermissionId="KibanaRemote" description="Kibana Remote Access"/>
     <moqui.security.UserGroupPermission userGroupId="ADMIN" userPermissionId="KibanaRemote" fromDate="0"/>
 
+    <moqui.security.UserPermission userPermissionId="GrafanaRemote" description="Grafana Remote Access"/>
+    <moqui.security.UserGroupPermission userGroupId="ADMIN" userPermissionId="GrafanaRemote" fromDate="0"/>
+
     <!-- Handy cron strings: [0 0 2 * * ?] every night at 2:00 am, [0 0/15 * * * ?] every 15 minutes, [0 0/2 * * * ?] every 2 minutes -->
     <moqui.service.job.ServiceJob jobName="clean_ElasticSearchLogMessages_daily" description="Clean log messages stored in ElasticSearch"
             serviceName="org.moqui.search.SearchServices.delete#Documents" cronExpression="0 0 2 * * ?" paused="Y">

--- a/framework/entity/ScreenEntities.xml
+++ b/framework/entity/ScreenEntities.xml
@@ -523,4 +523,27 @@ along with this software (see the LICENSE.md file). If not, see
         </field>
     </entity>
     -->
+
+    <!-- ========================================================= -->
+    <!-- moqui.screen.dashboard -->
+    <!-- ========================================================= -->
+
+    <entity entity-name="Dashboard" package="moqui.screen.dashboard" short-alias="dashboards" use="configuration" cache="true">
+        <description>Metadata for dashboards and external reports to be included in Moqui screens.</description>
+        <field name="dashboardId" type="id" is-pk="true"/>
+        <field name="dashboardTypeEnumId" type="id" not-null="true"/>
+        <field name="dashboardLocation" type="text-medium" not-null="true"/>
+        <field name="dashboardName" type="text-medium" not-null="true"/>
+        <field name="description" type="text-long"/>
+
+        <relationship type="one" title="DashboardType" related="moqui.basic.Enumeration" short-alias="type">
+            <key-map field-name="dashboardTypeEnumId"/></relationship>
+        <seed-data>
+            <!-- Dashboard Type -->
+            <moqui.basic.EnumerationType description="Dashboard Type" enumTypeId="DashboardType"/>
+            <moqui.basic.Enumeration description="Screen Widgets Dashboard" enumId="DashScreenWidgets" enumTypeId="DashboardType"/>
+            <moqui.basic.Enumeration description="Kibana Dashboard" enumId="DashKibana" enumTypeId="DashboardType"/>
+            <moqui.basic.Enumeration description="Grafana Dashboard" enumId="DashGrafana" enumTypeId="DashboardType"/>
+        </seed-data>
+    </entity>
 </entities>


### PR DESCRIPTION
Adds framework-level metadata for dashboards stored in the database.

Files changed:
- framework/entity/ScreenEntities.xml
- framework/data/MoquiSetupData.xml

This stays in moqui-framework because it defines generic dashboard entity and enum metadata rather than application-specific records.

Validation performed:
- git diff --check
- xmllint --noout on changed XML files

This PR supersedes moqui/moqui-framework#721 for the Dashboard portion.
