### PR TITLE
Add scheduled service API and XML actions

### DIFF
--- a/framework/src/main/groovy/org/moqui/impl/service/ServiceCallScheduledImpl.groovy
+++ b/framework/src/main/groovy/org/moqui/impl/service/ServiceCallScheduledImpl.groovy
@@ -1,0 +1,419 @@
+/*
+ * This software is in the public domain under CC0 1.0 Universal plus a
+ * Grant of Patent License.
+ *
+ * To the extent possible under law, the author(s) have dedicated all
+ * copyright and related and neighboring rights to this software to the
+ * public domain worldwide. This software is distributed without any
+ * warranty.
+ *
+ * You should have received a copy of the CC0 Public Domain Dedication
+ * along with this software (see the LICENSE.md file). If not, see
+ * <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org.moqui.impl.service
+
+import groovy.transform.CompileStatic
+import org.moqui.Moqui
+import org.moqui.impl.context.ExecutionContextFactoryImpl
+import org.moqui.impl.context.ExecutionContextImpl
+import org.moqui.service.ServiceCallScheduled
+import org.moqui.service.ServiceException
+import org.moqui.service.ServiceCallSync
+
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+
+import java.util.concurrent.Callable
+import java.util.concurrent.ScheduledFuture
+import java.util.concurrent.TimeUnit
+
+@CompileStatic
+class ServiceCallScheduledImpl extends ServiceCallImpl implements ServiceCallScheduled {
+    protected final static Logger logger = LoggerFactory.getLogger(ServiceCallScheduledImpl.class)
+
+    protected String taskName = null
+    protected ScheduledServiceInfo scheduledServiceInfo = null
+    protected ScheduledFuture scheduledFuture = null
+    protected boolean isOneShot = true
+    protected boolean isPeriodic = false
+    protected TimeUnit unit = TimeUnit.MILLISECONDS
+    protected Long initialDelay = 0L
+    protected Integer transactionTimeout = null
+    protected Long period
+    protected Long delay
+    protected Long duration
+
+    ServiceCallScheduledImpl(ServiceFacadeImpl sfi) {
+        super(sfi)
+    }
+
+    ServiceCallScheduledImpl(ServiceFacadeImpl sfi, String taskName) {
+        super(sfi)
+        this.taskName(taskName)
+    }
+
+    @Override
+    ServiceCallScheduled name(String serviceName) { serviceNameInternal(serviceName); return this }
+    @Override
+    ServiceCallScheduled name(String v, String n) { serviceNameInternal(null, v, n); return this }
+    @Override
+    ServiceCallScheduled name(String p, String v, String n) { serviceNameInternal(p, v, n); return this }
+
+    @Override
+    ServiceCallScheduled parameters(Map<String, Object> map) { parameters.putAll(map); return this }
+    @Override
+    ServiceCallScheduled parameter(String name, Object value) { parameters.put(name, value); return this }
+
+    @Override
+    String getTaskName() { return this.taskName }
+
+    @Override
+    ServiceCallScheduled taskName(String taskName) {
+        if (taskName == null) throw new IllegalArgumentException("The argument taskName is null.")
+        this.taskName = taskName
+        // try to get and restore existing scheduledFuture by taskName
+        this.scheduledFuture = sfi.getScheduledFuture(taskName)
+        return this
+    }
+
+    @Override
+    ServiceCallScheduled timeUnit(TimeUnit unit) { this.unit = unit; return this }
+
+    @Override
+    ServiceCallScheduled initialDelay(long delay) { this.initialDelay = delay; return this }
+
+    @Override
+    ServiceCallScheduled transactionTimeout(int transactionTimeout)  { this.transactionTimeout = transactionTimeout; return this }
+
+    @Override
+    ServiceCallScheduled atFixedRate(long period) { this.period = period; this.delay = null; this.isOneShot = false; this.isPeriodic = true; return this }
+
+    @Override
+    ServiceCallScheduled withFixedDelay(long delay) { this.delay = delay; this.period = null; this.isOneShot = false; this.isPeriodic = true; return this }
+
+    @Override
+    ServiceCallScheduled duration(long duration) { this.duration = duration; return this }
+
+    @Override
+    ServiceCallScheduled call() throws ServiceException {
+        if (!taskName) throw new IllegalStateException("taskName is required for call()")
+
+        // guard: if we already have a running future for this builder, return
+        if (scheduledFuture != null && this.isRunning()) {
+            logger.warn("A previous scheduled service call [${taskName}] is still running. To terminate the previous scheduling use the cancel() method.")
+            return this
+        }
+        // guard: if another task with the same name is already scheduled, reuse it and return
+        ScheduledFuture existing = sfi.getScheduledFuture(taskName)
+        if (existing != null && !existing.isCancelled() && !existing.isDone()) {
+            logger.warn("A previous scheduled service call [${taskName}] is still running. To terminate the previous scheduling use the cancel() method.")
+            this.scheduledFuture = existing
+            return this
+        }
+
+        ExecutionContextFactoryImpl ecfi = sfi.ecfi
+        ExecutionContextImpl eci = ecfi.getEci()
+        validateCall(eci)
+
+        // runs the scheduled service and gets the scheduleFuture
+        ScheduledServiceRunnable runnable
+        if (transactionTimeout != null) {
+            runnable = new ScheduledServiceRunnable(eci, serviceName, parameters, taskName, transactionTimeout)
+        } else {
+            runnable = new ScheduledServiceRunnable(eci, serviceName, parameters, taskName)
+        }
+        scheduledServiceInfo = runnable
+
+        if (isOneShot) {
+            scheduledFuture = sfi.scheduledExecutor.schedule(runnable, initialDelay, unit)
+        } else if (isPeriodic) {
+            if (period != null && period >= 0) {
+                scheduledFuture = sfi.scheduledExecutor.scheduleAtFixedRate(runnable, initialDelay, period, unit)
+                if (duration > 0) cancel(false, duration, unit)
+            } else if (delay != null && delay >= 0) {
+                scheduledFuture = sfi.scheduledExecutor.scheduleWithFixedDelay(runnable, initialDelay, delay, unit)
+                if (duration > 0) cancel(false, duration, unit)
+            } else {
+                throw new IllegalStateException("Periodic scheduling requested but neither period nor delay was set for task [${taskName}].")
+            }
+        } else {
+            throw new IllegalStateException("Schedule mode not set (one-shot/periodic) for task [${taskName}].")
+        }
+
+        if (scheduledFuture == null) throw new IllegalStateException("Scheduler returned null ScheduledFuture for task [${taskName}].")
+
+        sfi.putScheduledFuture(taskName, scheduledFuture)
+        return this
+    }
+
+    @Override
+    ScheduledFuture<Map<String, Object>> callFuture() throws ServiceException {
+        if (!taskName) throw new IllegalStateException("taskName is required for call()")
+
+        // guard: if we already have a running future for this builder, return
+        if (scheduledFuture != null && this.isRunning()) {
+            logger.warn("A previous scheduled service call [${taskName}] is still running. To terminate the previous scheduling use the cancel() method.")
+            return scheduledFuture
+        }
+        // guard: if another task with the same name is already scheduled, reuse it and return
+        ScheduledFuture existing = sfi.getScheduledFuture(taskName)
+        if (existing != null && !existing.isCancelled() && !existing.isDone()) {
+            logger.warn("A previous scheduled service call [${taskName}] is still running. To terminate the previous scheduling use the cancel() method.")
+            this.scheduledFuture = existing
+            return (ScheduledFuture<Map<String, Object>>) existing
+        }
+
+        if (isPeriodic) throw new IllegalStateException("You cannot call the callFuture method for periodic service, with fixed delay or at fixed rate.")
+
+        ExecutionContextFactoryImpl ecfi = sfi.ecfi
+        ExecutionContextImpl eci = ecfi.getEci()
+        validateCall(eci)
+
+        ScheduledServiceCallable callable
+        if (transactionTimeout != null)
+            callable = new ScheduledServiceCallable(eci, serviceName, parameters, taskName, transactionTimeout)
+        else
+            callable = new ScheduledServiceCallable(eci, serviceName, parameters, taskName)
+
+        scheduledServiceInfo = callable
+
+        scheduledFuture = sfi.scheduledExecutor.schedule(callable, initialDelay, unit)
+        if (duration > 0) cancel(false, duration, unit)
+        return scheduledFuture
+    }
+
+    boolean cancel(boolean mayInterruptIfRunning) {
+        if (!taskName) throw new IllegalStateException("taskName is required for cancel()")
+
+        // resolve future from this builder or by taskName (so cancel works from a new builder)
+        ScheduledFuture sf = scheduledFuture
+        if (sf == null) {
+            if (sf == null) sf = sfi.getScheduledFuture(taskName)
+            if (sf == null) {
+                logger.error("No scheduled task found with name [${taskName}] to cancel")
+                return false
+            }
+            // remember it locally so isRunning() etc keep working
+            scheduledFuture = sf
+        }
+
+        boolean cancelled = sf.cancel(mayInterruptIfRunning)
+        if (cancelled) sfi.removeScheduledFuture(taskName)
+        return cancelled
+    }
+
+    ScheduledFuture cancel(boolean mayInterruptIfRunning, long cancelDelay, TimeUnit unit) {
+        if (!taskName) throw new IllegalStateException("taskName is required for cancel(delay)")
+        if (cancelDelay <= 0)  throw new IllegalArgumentException("You cannot call the cancel method with an invalid cancelDelay argument.")
+
+        // Resolve the future eagerly so delayed cancellation does not depend on a later cluster lookup by task name.
+        ScheduledFuture sf = scheduledFuture
+        if (sf == null) {
+            sf = sfi.getScheduledFuture(taskName)
+            if (sf != null) scheduledFuture = sf
+        }
+        final ScheduledFuture sfFinal = sf
+        final String tnFinal = taskName
+
+        Runnable runnable = new Runnable() {
+            @Override
+            void run() {
+                try {
+                    boolean cancelled = false
+                    if (sfFinal != null) {
+                        cancelled = sfFinal.cancel(mayInterruptIfRunning)
+                        if (cancelled) sfi.removeScheduledFuture(tnFinal)
+                    } else {
+                        cancelled = cancel(mayInterruptIfRunning)
+                    }
+                    if (!cancelled) logger.error("No scheduled task found with name [${tnFinal}] to cancel")
+                } catch (Throwable t) {
+                    logger.warn("Error cancelling scheduled service [${tnFinal}] from delayed cancellation runnable: ${t.toString()}")
+                }
+            }
+        }
+        return sfi.scheduledExecutor.schedule(runnable, cancelDelay, unit)
+    }
+
+    @Override
+    ScheduledFuture cancel(boolean mayInterruptIfRunning, long cancelDelay) {
+        return cancel(mayInterruptIfRunning, cancelDelay, TimeUnit.MILLISECONDS)
+    }
+
+    @Override
+    boolean isCancelled() {
+        if (scheduledFuture == null) throw new IllegalStateException("Must call method call() or callFuture() before using ScheduledFuture interface methods")
+        return scheduledFuture.isCancelled()
+    }
+
+    @Override
+    boolean isDone() {
+        if (scheduledFuture == null) throw new IllegalStateException("Must call method call() or callFuture() before using ScheduledFuture interface methods")
+        return scheduledFuture.isDone()
+    }
+
+    @Override
+    boolean isRunning() {
+        if (scheduledFuture == null) throw new IllegalStateException("Must call call() or callFuture() before using ScheduledFuture interface methods")
+        return (!scheduledFuture.isCancelled() && !scheduledFuture.isDone())
+    }
+
+    @Override
+    Runnable getRunnable() {
+        if (this.transactionTimeout != null)
+            return new ScheduledServiceRunnable(sfi.ecfi.getEci(), serviceName, parameters, taskName, transactionTimeout)
+        else
+            return new ScheduledServiceRunnable(sfi.ecfi.getEci(), serviceName, parameters, taskName)
+    }
+
+    @Override
+    Callable<Map<String, Object>> getCallable() {
+        if (this.transactionTimeout != null)
+            return new ScheduledServiceCallable(sfi.ecfi.getEci(), serviceName, parameters, taskName, transactionTimeout)
+        else
+            return new ScheduledServiceCallable(sfi.ecfi.getEci(), serviceName, parameters, taskName)
+    }
+
+    static class ScheduledServiceInfo implements Externalizable {
+        transient ExecutionContextFactoryImpl ecfiLocal
+        String threadUsername
+        String serviceName, taskName
+        Map<String, Object> parameters
+        Integer transactionTimeout = null
+
+        ScheduledServiceInfo() { }
+        ScheduledServiceInfo(ExecutionContextImpl eci, String serviceName, Map<String, Object> parameters, String taskName) {
+            ecfiLocal = eci.ecfi
+            threadUsername = eci.userFacade.username
+            this.serviceName = serviceName
+            this.parameters = new HashMap<>(parameters)
+            this.taskName = taskName
+        }
+        ScheduledServiceInfo(ExecutionContextImpl eci, String serviceName, Map<String, Object> parameters, String taskName, int transactionTimeout) {
+            ecfiLocal = eci.ecfi
+            threadUsername = eci.userFacade.username
+            this.serviceName = serviceName
+            this.parameters = new HashMap<>(parameters)
+            this.taskName = taskName
+            this.transactionTimeout = transactionTimeout
+        }
+        ScheduledServiceInfo(ExecutionContextFactoryImpl ecfi, String username, String serviceName, Map<String, Object> parameters, String taskName) {
+            ecfiLocal = ecfi
+            threadUsername = username
+            this.serviceName = serviceName
+            this.parameters = new HashMap<>(parameters)
+            this.taskName = taskName
+        }
+        ScheduledServiceInfo(ExecutionContextFactoryImpl ecfi, String username, String serviceName, Map<String, Object> parameters, String taskName, int transactionTimeout) {
+            ecfiLocal = ecfi
+            threadUsername = username
+            this.serviceName = serviceName
+            this.parameters = new HashMap<>(parameters)
+            this.taskName = taskName
+            this.transactionTimeout = transactionTimeout
+        }
+
+        @Override
+        void writeExternal(ObjectOutput out) throws IOException {
+            out.writeObject(threadUsername) // might be null
+            out.writeUTF(serviceName) // never null
+            out.writeObject(parameters)
+            out.writeUTF(taskName)
+            out.writeInt(transactionTimeout != null ? transactionTimeout.intValue() : 0)
+        }
+
+        @Override
+        void readExternal(ObjectInput objectInput) throws IOException, ClassNotFoundException {
+            threadUsername = (String) objectInput.readObject()
+            serviceName = objectInput.readUTF()
+            parameters = (Map<String, Object>) objectInput.readObject()
+            taskName = objectInput.readUTF()
+            int tx = objectInput.readInt()
+            transactionTimeout = (tx == 0 ? null : Integer.valueOf(tx))
+        }
+
+        ExecutionContextFactoryImpl getEcfi() {
+            if (ecfiLocal == null) ecfiLocal = (ExecutionContextFactoryImpl) Moqui.getExecutionContextFactory()
+            return ecfiLocal
+        }
+
+        Map<String, Object> runInternal() throws Exception {
+            return runInternal(null, false)
+        }
+        Map<String, Object> runInternal(Map<String, Object> parameters, boolean skipEcCheck) throws Exception {
+            ExecutionContextImpl threadEci = (ExecutionContextImpl) null
+            try {
+                // check for active Transaction
+                if (getEcfi().transactionFacade.isTransactionInPlace()) {
+                    logger.error("In ServiceCallScheduled service ${serviceName} a transaction is in place for thread ${Thread.currentThread().getName()}, trying to commit")
+                    try {
+                        getEcfi().transactionFacade.destroyAllInThread()
+                    } catch (Exception e) {
+                        logger.error("ServiceCallScheduled commit in place transaction failed for thread ${Thread.currentThread().getName()}", e)
+                    }
+                }
+                // check for active ExecutionContext
+                if (!skipEcCheck) {
+                    ExecutionContextImpl activeEc = getEcfi().activeContext.get()
+                    if (activeEc != null) {
+                        logger.error("In ServiceCallScheduled service ${serviceName} there is already an ExecutionContext for user ${activeEc.user.username} (from ${activeEc.forThreadId}:${activeEc.forThreadName}) in this thread ${Thread.currentThread().id}:${Thread.currentThread().name}, destroying")
+                        try {
+                            activeEc.destroy()
+                        } catch (Throwable t) {
+                            logger.error("Error destroying ExecutionContext already in place in ServiceCallScheduled in thread ${Thread.currentThread().id}:${Thread.currentThread().name}", t)
+                        }
+                    }
+                }
+
+                threadEci = getEcfi().getEci()
+                if (threadUsername != null && threadUsername.length() > 0) {
+                    threadEci.userFacade.internalLoginUser(threadUsername, false)
+                } else {
+                    threadEci.userFacade.loginAnonymousIfNoUser()
+                }
+
+                Map<String, Object> parmsToUse = this.parameters
+                if (parameters != null) {
+                    parmsToUse = new HashMap<>(this.parameters)
+                    parmsToUse.putAll(parameters)
+                }
+
+                // NOTE: authz is disabled because authz is checked before queueing
+                ServiceCallSync serviceCallSync = threadEci.serviceFacade.sync().name(serviceName).parameters(parmsToUse)
+                if (this.transactionTimeout) serviceCallSync.transactionTimeout(transactionTimeout)
+                Map<String, Object> results = serviceCallSync.disableAuthz().call()
+                return results
+            } catch (Throwable t) {
+                logger.error("Error in scheduling service call", t)
+                throw t
+            } finally {
+                if (threadEci != null) threadEci.destroy()
+            }
+        }
+    }
+
+    static class ScheduledServiceRunnable extends ScheduledServiceInfo implements Runnable, Externalizable {
+        ScheduledServiceRunnable() { super() }
+        ScheduledServiceRunnable(ExecutionContextImpl eci, String serviceName, Map<String, Object> parameters, String taskName) {
+            super(eci, serviceName, parameters, taskName)
+        }
+        ScheduledServiceRunnable(ExecutionContextImpl eci, String serviceName, Map<String, Object> parameters, String taskName, int transactionTimeout) {
+            super(eci, serviceName, parameters, taskName, transactionTimeout)
+        }
+        @Override void run() { runInternal() }
+    }
+
+
+    static class ScheduledServiceCallable extends ScheduledServiceInfo implements Callable<Map<String, Object>>, Externalizable {
+        ScheduledServiceCallable() { super() }
+        ScheduledServiceCallable(ExecutionContextImpl eci, String serviceName, Map<String, Object> parameters, String taskName) {
+            super(eci, serviceName, parameters, taskName)
+        }
+        ScheduledServiceCallable(ExecutionContextImpl eci, String serviceName, Map<String, Object> parameters, String taskName, int transactionTimeout) {
+            super(eci, serviceName, parameters, taskName, transactionTimeout)
+        }
+        @Override Map<String, Object> call() throws Exception { return runInternal() }
+    }
+
+}

--- a/framework/src/main/groovy/org/moqui/impl/service/ServiceFacadeImpl.groovy
+++ b/framework/src/main/groovy/org/moqui/impl/service/ServiceFacadeImpl.groovy
@@ -1,12 +1,12 @@
 /*
  * This software is in the public domain under CC0 1.0 Universal plus a
  * Grant of Patent License.
- * 
+ *
  * To the extent possible under law, the author(s) have dedicated all
  * copyright and related and neighboring rights to this software to the
  * public domain worldwide. This software is distributed without any
  * warranty.
- * 
+ *
  * You should have received a copy of the CC0 Public Domain Dedication
  * along with this software (see the LICENSE.md file). If not, see
  * <http://creativecommons.org/publicdomain/zero/1.0/>.
@@ -64,6 +64,10 @@ class ServiceFacadeImpl implements ServiceFacade {
 
     /** Distributed ExecutorService for async services, etc */
     protected ExecutorService distributedExecutorService = null
+    /** An executor for scheduled services */
+    protected CustomScheduledExecutor scheduledExecutor = null
+    /** Map of all serviceCallScheduled scheduledFuture (not concelled yet), using taskName as the key. */
+    protected final ConcurrentMap<String, ScheduledFuture<?>> scheduledFutureMap = new ConcurrentHashMap<>()
 
     protected final ConcurrentMap<String, List<ServiceCallback>> callbackRegistry = new ConcurrentHashMap<>()
 
@@ -84,6 +88,7 @@ class ServiceFacadeImpl implements ServiceFacade {
         restApi = new RestApi(ecfi)
 
         jobWorkerPool = makeWorkerPool()
+        scheduledExecutor = makeScheduledExecutor()
     }
 
     private ThreadPoolExecutor makeWorkerPool() {
@@ -104,6 +109,16 @@ class ServiceFacadeImpl implements ServiceFacade {
         BlockingQueue<Runnable> workQueue = new LinkedBlockingQueue<>(jobQueueMax < maxSize ? maxSize : jobQueueMax)
         return new ContextJavaUtil.WorkerThreadPoolExecutor(ecfi, coreSize, maxSize, aliveTime, TimeUnit.SECONDS,
                 workQueue, new ContextJavaUtil.JobThreadFactory())
+    }
+
+    private CustomScheduledExecutor makeScheduledExecutor() {
+        MNode serviceFacadeNode = ecfi.confXmlRoot.first("service-facade")
+
+        int coreSize = (serviceFacadeNode.attribute("scheduled-thread-pool-core") ?: "16") as int
+        int maxSize = (serviceFacadeNode.attribute("scheduled-thread-pool-max") ?: "32") as int
+        CustomScheduledExecutor executor = new CustomScheduledExecutor(coreSize)
+        executor.setMaximumPoolSize(maxSize)
+        return executor
     }
 
     void postFacadeInit() {
@@ -164,11 +179,24 @@ class ServiceFacadeImpl implements ServiceFacade {
     void destroy() {
         // destroy all service runners
         for (ServiceRunner sr in serviceRunners.values()) sr.destroy()
+
+        // shutdown scheduled executor
+        try {
+            logger.info("Shutting scheduled executor")
+            scheduledExecutor.shutdown()
+            scheduledExecutor.awaitTermination(30, TimeUnit.SECONDS)
+            if (scheduledExecutor.isTerminated()) logger.info("Scheduled executor shut down and terminated")
+            else logger.warn("Scheduled executor not yet terminated, waited 30 seconds")
+        } catch (Throwable t) {
+            logger.error("Error in scheduledExecutor shutdown", t)
+        }
     }
 
     ServiceRunner getServiceRunner(String type) { serviceRunners.get(type) }
     // NOTE: this is used in the ServiceJobList screen
     ScheduledJobRunner getJobRunner() { jobRunner }
+
+    long getJobRunnerRate() { jobRunnerRate }
 
     boolean isServiceDefined(String serviceName) {
         ServiceDefinition sd = getServiceDefinition(serviceName)
@@ -568,10 +596,71 @@ class ServiceFacadeImpl implements ServiceFacade {
         for (EmailEcaRule eer in emecaRuleList) eer.runIfMatches(message, emailServerId, eci)
     }
 
+    /**
+     * True if a task with this name is registered.
+     *
+     * @param taskName Unique task name.
+     * @return true if a name is registerd
+    */
+    boolean hasScheduledFuture(String taskName) {
+        return taskName && scheduledFutureMap.containsKey(taskName)
+    }
+
+    /** Get the scheduled future for a scheduled service call by taskName.
+     * @param taskName Unique task name with which the specified scheduled future is associated.
+     * @return scheduledFuture - scheduledFuture associated with the specified task name.
+     */
+    ScheduledFuture<?> getScheduledFuture(String taskName) {
+        return (ScheduledFuture) scheduledFutureMap.get(taskName)
+    }
+
+    /** Associates the specified scheduled future for a scheduled service call with the specified taskName.
+     * @param taskName Unique task name with which the specified scheduled future is to be associated.
+     * @param scheduledFuture - scheduledFuture to be associated with the specified task name.
+     */
+    ScheduledFuture<?> putScheduledFuture(String taskName, ScheduledFuture<?> scheduledFuture) {
+        if (taskName == null) throw new IllegalArgumentException("The argument taskName is null.")
+        if (scheduledFuture == null) throw new IllegalArgumentException("The argument scheduledFuture is null.")
+        return scheduledFutureMap.put(taskName, scheduledFuture)
+    }
+
+    /** If the specified taskName is not already associated with a scheduled future associates it
+     *  with the given instance and returns null, else returns the current scheduled future.
+     * @param taskName Unique task name with which the specified scheduled future is to be associated.
+     * @param scheduledFuture - scheduledFuture to be associated with the specified task name.
+     */
+    ScheduledFuture<?> putScheduledFutureIfAbsent(String taskName, ScheduledFuture<?> scheduledFuture) {
+        if (taskName == null) throw new IllegalArgumentException("The argument taskName is null.")
+        if (scheduledFuture == null) throw new IllegalArgumentException("The argument scheduledFuture is null.")
+        return (ScheduledFuture<?>) scheduledFutureMap.putIfAbsent(taskName, scheduledFuture)
+    }
+
+    /** Removes the entry for the scheduled future and the associated taskName if it is present.
+     * @param taskName Unique task name for which the specified scheduled future is to be removed.
+     */
+    boolean removeScheduledFuture(String taskName) {
+        if (taskName == null) throw new IllegalArgumentException("The argument taskName is null.")
+        return scheduledFutureMap.remove(taskName)
+    }
+
+    /** Snapshot of current scheduled future task names. */
+    List<String> listScheduledFutureTaskNames() {
+        return new ArrayList<>(scheduledFutureMap.keySet())
+    }
+
+    /** Current scheduled future count. */
+    int scheduledFutureCount() {
+        return scheduledFutureMap.size()
+    }
+
     @Override
     ServiceCallSync sync() { return new ServiceCallSyncImpl(this) }
     @Override
     ServiceCallAsync async() { return new ServiceCallAsyncImpl(this) }
+    @Override
+    ServiceCallScheduled schedule(String taskName) { return new ServiceCallScheduledImpl(this, taskName) }
+    @Override
+    ServiceCallScheduled schedule() { return new ServiceCallScheduledImpl(this) }
     @Override
     ServiceCallJob job(String jobName) { return new ServiceCallJobImpl(jobName, this) }
 

--- a/framework/src/main/java/org/moqui/service/ServiceCallScheduled.java
+++ b/framework/src/main/java/org/moqui/service/ServiceCallScheduled.java
@@ -1,0 +1,109 @@
+/*
+ * This software is in the public domain under CC0 1.0 Universal plus a
+ * Grant of Patent License.
+ *
+ * To the extent possible under law, the author(s) have dedicated all
+ * copyright and related and neighboring rights to this software to the
+ * public domain worldwide. This software is distributed without any
+ * warranty.
+ *
+ * You should have received a copy of the CC0 Public Domain Dedication
+ * along with this software (see the LICENSE.md file). If not, see
+ * <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org.moqui.service;
+
+import java.util.Map;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+
+
+/** Example use:
+ *      ec.service.schedule().name("...").parameters([...]).initialDelay(50).atFixedRate(100).call()
+ *      ec.service.schedule().name("...").parameters([...]).initialDelay(50).callFuture()
+ *      ec.service.schedule().name("....").getScheduledFuture(urn).shutdown()
+ */
+@SuppressWarnings("unused")
+public interface ServiceCallScheduled extends ServiceCall {
+    /** Name of the service to run. The combined service name, like: "${path}.${verb}${noun}". To explicitly separate
+     * the verb and noun put a hash (#) between them, like: "${path}.${verb}#${noun}" (this is useful for calling the
+     * implicit entity CrUD services where verb is create, update, or delete and noun is the name of the entity).
+     */
+    ServiceCallScheduled name(String serviceName);
+
+    ServiceCallScheduled name(String verb, String noun);
+
+    ServiceCallScheduled name(String path, String verb, String noun);
+
+    /** Map of name, value pairs that make up the context (in parameters) passed to the service. */
+    ServiceCallScheduled parameters(Map<String, Object> context);
+
+    /** Single name, value pairs to put in the context (in parameters) passed to the service. */
+    ServiceCallScheduled parameter(String name, Object value);
+
+    /** Returns the name of the task for the scheduled service. */
+    String getTaskName();
+
+    /** Set a unique task name for the scheduled service. */
+    ServiceCallScheduled taskName(String taskName);
+
+    /** The time unit for all time parameters. Defaults to milliseconds. */
+    ServiceCallScheduled timeUnit(TimeUnit unit);
+
+    /** The service execution becomes enabled after the given initial delay. Defaults to 0. */
+    ServiceCallScheduled initialDelay(long delay) throws IllegalArgumentException;
+
+    /** The maximum time to wait before timeout for each service call. Override the transaction-timeout attribute in the service definition. */
+    ServiceCallScheduled transactionTimeout(int transactionTimeout);
+
+    /** Creates a periodic service that becomes enabled first after the given initial delay, and subsequently with the given period; that is executions will commence after initialDelay then initialDelay+period, then initialDelay + 2 * period, and so on. */
+    ServiceCallScheduled atFixedRate(long period) throws IllegalArgumentException;
+
+    /** Creates a periodic service that becomes enabled first after the given initial delay, and subsequently with the given delay between the termination of one execution and the commencement of the next. */
+    ServiceCallScheduled withFixedDelay(long delay) throws IllegalArgumentException;
+
+    /** The duration of the execution of the periodic task. After this duration the cyclical task will be canceled. */
+    ServiceCallScheduled duration(long duration);
+
+    /**
+     * Submits the service for the scheduled execution, ignoring the result.
+     * This effectively calls the service through a java.lang.Runnable implementation.
+     */
+    ServiceCallScheduled call() throws ServiceException;
+
+    /**
+     * Submits the service for the scheduled execution and get a java.util.concurrent.ScheduledFuture object back so you can wait for the service to
+     * complete and get the result.
+     *
+     * This effectively calls the service through a java.util.concurrent.Callable implementation.
+     */
+    ScheduledFuture<Map<String, Object>> callFuture() throws ServiceException;
+
+    /** Attempts to cancel the scheduled execution of this service. */
+    boolean cancel(boolean mayInterruptIfRunning);
+
+    /** Attempts to cancel the scheduled execution of this service after the specified delay.
+     *  Returns the SheduledFuture of the cancel task.
+     */
+    <V> ScheduledFuture<V> cancel(boolean mayInterruptIfRunning, long cancelDelay, TimeUnit unit);
+
+    /** Attempts to cancel the scheduled execution of this service after the specified delay.
+     *  Returns the SheduledFuture of the cancel task.
+     */
+    <V> ScheduledFuture<V> cancel(boolean mayInterruptIfRunning, long cancelDelay);
+
+    /** Returns true if this scheduled service was cancelled before it completed normally. */
+    boolean isCancelled();
+
+    /** Returns true if this scheduled service completed. Completion may be due to normal termination, an exception, or cancellation -- in all of these cases, this method will return true. */
+    boolean isDone();
+
+    /** Returns true if this scheduled service has not completed. */
+    boolean isRunning();
+
+    /** Get a Runnable object to do this service call through an ExecutorService or other runner of your choice. */
+    Runnable getRunnable();
+    /** Get a Callable object to do this service call through an ExecutorService of your choice. */
+    Callable<Map<String, Object>> getCallable();
+}

--- a/framework/src/main/java/org/moqui/service/ServiceFacade.java
+++ b/framework/src/main/java/org/moqui/service/ServiceFacade.java
@@ -1,12 +1,12 @@
 /*
  * This software is in the public domain under CC0 1.0 Universal plus a
  * Grant of Patent License.
- * 
+ *
  * To the extent possible under law, the author(s) have dedicated all
  * copyright and related and neighboring rights to this software to the
  * public domain worldwide. This software is distributed without any
  * warranty.
- * 
+ *
  * You should have received a copy of the CC0 Public Domain Dedication
  * along with this software (see the LICENSE.md file). If not, see
  * <http://creativecommons.org/publicdomain/zero/1.0/>.
@@ -16,6 +16,7 @@ package org.moqui.service;
 import org.moqui.util.RestClient;
 
 import java.util.Map;
+import java.util.concurrent.ScheduledFuture;
 
 /** ServiceFacade Interface */
 @SuppressWarnings("unused")
@@ -26,6 +27,12 @@ public interface ServiceFacade {
 
     /** Get a service caller to call a service asynchronously. */
     ServiceCallAsync async();
+
+    /** Get a service caller to schedule a service call. */
+    ServiceCallScheduled schedule();
+
+    /** Get a service caller to schedule a service, assigning a specific taskName. */
+    ServiceCallScheduled schedule(String taskName);
 
     /**
      * Get a service caller to call a service job.

--- a/framework/src/main/resources/MoquiDefaultConf.xml
+++ b/framework/src/main/resources/MoquiDefaultConf.xml
@@ -42,6 +42,8 @@
     <default-property name="webapp_client_ip_header" value=""/>
 
     <!-- Properties for the primary (transactional group) datasource -->
+
+    <!-- H2 -->
     <default-property name="entity_ds_db_conf" value="h2"/>
     <default-property name="entity_ds_host" value="127.0.0.1"/>
     <default-property name="entity_ds_port" value=""/>
@@ -50,6 +52,32 @@
     <default-property name="entity_ds_schema" value=""/>
     <default-property name="entity_ds_user" value="sa"/>
     <default-property name="entity_ds_password" value="sa" is-secret="true"/>
+    <!-- Uncomment for Postgres -->
+    <!--
+    <default-property name="entity_ds_db_conf" value="postgres"/>
+    <default-property name="entity_ds_host" value="localhost"/>
+    <default-property name="entity_ds_port" value="5432"/>
+    <default-property name="entity_ds_database" value="moqui"/>
+    -->
+    <!-- <default-property name="entity_ds_url" value="jdbc:postgresql://moqui-database1:5432,moqui-database2:5432/${entity_ds_database}?targetServerType=primary"/> -->
+    <!--
+    <default-property name="entity_ds_url" value="jdbc:postgresql://localhost:5432/${entity_ds_database}"/>
+    <default-property name="entity_ds_schema" value="public"/>
+    <default-property name="entity_ds_user" value="moqui"/>
+    <default-property name="entity_ds_password" value="moqui" is-secret="true"/>
+    -->
+    <!-- Uncomment for Yugabyte -->
+    <!--
+    <default-property name="entity_ds_db_conf" value="yugabyte"/>
+    <default-property name="entity_ds_host" value="localhost"/>
+    <default-property name="entity_ds_port" value="5433"/>
+    <default-property name="entity_ds_database" value="moqui"/>
+    <default-property name="entity_ds_url" value="jdbc:yugabytedb://localhost:5433,localhost:5434,localhost:5435/${entity_ds_database}?loadBalanceHosts=true"/>
+    <default-property name="entity_ds_schema" value="public"/>
+    <default-property name="entity_ds_user" value="moqui"/>
+    <default-property name="entity_ds_password" value="moqui" is-secret="true"/>
+    -->
+
     <default-property name="entity_ds_crypt_pass" value="MoquiDefaultPassword:CHANGEME" is-secret="true"/>
     <default-property name="entity_ds_crypt_pass_old" value="MoquiDefaultPassword:CHANGEME" is-secret="true"/>
     <default-property name="entity_add_missing_runtime" value="false"/>
@@ -68,6 +96,7 @@
     <default-property name="entity_ds_c1_host" value=""/>
     <default-property name="entity_ds_c1_port" value=""/>
     <default-property name="entity_ds_c1_database" value=""/>
+    <!-- <default-property name="entity_ds_c1_url" value="jdbc:postgresql://moqui-database1:5432,moqui-database2:5432/${entity_ds_database}?targetServerType=secondary&amp;loadBalanceHosts=true&amp;readOnly=true"/> -->
     <default-property name="entity_ds_c1_user" value=""/>
     <default-property name="entity_ds_c1_password" value="" is-secret="true"/>
 
@@ -82,6 +111,9 @@
     <!-- Kibana Proxy Servlet settings -->
     <default-property name="kibana_host" value="127.0.0.1"/>
     <default-property name="kibana_port" value="5601"/>
+    <!-- Grafana Proxy Servlet settings -->
+    <default-property name="grafana_host" value="127.0.0.1"/>
+    <default-property name="grafana_port" value="3000"/>
 
     <tools worker-queue="65535" worker-pool-core="16" worker-pool-max="32" worker-pool-alive="60"
             empty-db-load="${entity_empty_db_load}"
@@ -209,6 +241,10 @@
                 <init-param name="permission" value="KibanaRemote"/>
                 <url-pattern>/kibana/*</url-pattern>
             </filter>
+            <filter name="GrafanaAuthFilter" class="org.moqui.impl.webapp.MoquiAuthFilter" async-supported="true">
+                <init-param name="permission" value="GrafanaRemote"/>
+                <url-pattern>/grafana/*</url-pattern>
+            </filter>
 
             <!-- Moqui Session Listener (necessary to handle expired sessions, etc) -->
             <listener class="org.moqui.impl.webapp.MoquiSessionListener"/>
@@ -233,6 +269,14 @@
                 <init-param name="proxyTo" value="http://${kibana_host}:${kibana_port}"/>
                 <init-param name="prefix" value="/kibana"/>
                 <url-pattern>/kibana/*</url-pattern>
+            </servlet>
+            <servlet name="GrafanaProxy" class="org.eclipse.jetty.ee11.proxy.ProxyServlet$Transparent" load-on-startup="1" async-supported="true">
+                <!-- this proxies to a Grafana instance run locally, in another container, etc -->
+                <!-- in grafana.yml set root_url = %(protocol)s://%(domain)s:%(http_port)s/grafana
+                        or using the environment variable set GF_SERVER_ROOT_URL=%(protocol)s://%(domain)s:%(http_port)s/grafana -->
+                <init-param name="proxyTo" value="http://${grafana_host}:${grafana_port}"/>
+                <init-param name="prefix" value="/grafana"/>
+                <url-pattern>/grafana/*</url-pattern>
             </servlet>
 
             <!-- timeout session in 60 minutes without a request -->
@@ -385,7 +429,8 @@
                 macro-template-location="template/screen-macro/DefaultScreenMacros.plain.ftl"/>
     </screen-facade>
 
-    <service-facade distributed-factory="" scheduled-job-check-time="${scheduled_job_check_time}"
+    <service-facade distributed-executor-factory="" distributed-scheduled-executor-factory=""
+            scheduled-thread-pool-core="16" scheduled-thread-pool-max="32" scheduled-job-check-time="${scheduled_job_check_time}"
             job-queue-max="0" job-pool-core="2" job-pool-max="8" job-pool-alive="120">
         <service-location name="main-json" location="http://localhost:8080/rpc/json"/>
 
@@ -427,7 +472,8 @@
     <entity-facade default-group-name="transactional" entity-eca-enabled="true" sequenced-id-prefix=""
             distributed-cache-invalidate="false" dci-topic-factory="" query-stats="false"
             database-locale="${default_locale}" database-time-zone="${database_time_zone ?: default_time_zone}"
-            crypt-salt="20201202" crypt-iter="10" crypt-algo="PBEWithHmacSHA256AndAES_128" crypt-pass="${entity_ds_crypt_pass}">
+            crypt-salt="20201202" crypt-iter="10" crypt-algo="PBEWithHmacSHA256AndAES_128" crypt-pass="${entity_ds_crypt_pass}"
+            worker-pool-queue="1024" worker-pool-core="5" worker-pool-max="100" worker-pool-alive="60">
 
         <!-- alternate decrypt using original algo (PBEWithMD5AndDES), etc for decrypting old values, all new values will encrypt using the 4 attributes on entity-facade element -->
         <decrypt-alt crypt-salt="SkcorIuqom" crypt-iter="10" crypt-algo="PBEWithMD5AndDES" crypt-pass="${entity_ds_crypt_pass}"/>
@@ -490,6 +536,8 @@
                         databaseName="${entity_ds_c1_database}" user="${entity_ds_c1_user}" password="${entity_ds_c1_password}"
                         pinGlobalTxToPhysicalConnection="true" autoReconnectForPools="true" useUnicode="true" encoding="UTF-8"/>
             </inline-jdbc>
+            <!-- Connection settings for PostgreSQL HA cluster -->
+            <!-- <inline-jdbc pool-maxsize="40" isolation-level="ReadUncommitted" jdbc-uri="${entity_ds_c1_url}" jdbc-username="${entity_ds_c1_user}" jdbc-password="${entity_ds_c1_password}"/> -->
         </datasource>
 
         <!-- The logging group and datasource uses the elastic-facade.cluster configuration to talk to Elastic/OpenSearch -->
@@ -859,6 +907,26 @@
             <!-- default max connections for PostgreSQL is 100 -->
             <inline-jdbc pool-maxsize="90"><xa-properties serverName="${entity_ds_host}" portNumber="${entity_ds_port?:'5432'}"
                     databaseName="${entity_ds_database}" user="${entity_ds_user}" password="${entity_ds_password}"/></inline-jdbc>
+            <!-- Connection settings for PostgreSQL HA cluster -->
+            <!-- <inline-jdbc pool-maxsize="90" jdbc-uri="${entity_ds_url}" jdbc-username="${entity_ds_user}" jdbc-password="${entity_ds_password}"/> -->
+        </database>
+
+        <!-- YugabyteDB (Smart JDBC Driver) -->
+        <database name="yugabyte" lb-name="yugabytedb" join-style="ansi" from-lateral-style="lateral" result-fetch-size="50"
+                never-try-insert="true" default-isolation-level="ReadCommitted" use-tm-join="true" default-test-query="SELECT 1"
+                constraint-name-clip-length="60" default-jdbc-driver="com.yugabyte.Driver" default-startup-add-missing="true"
+                default-runtime-add-missing="false" use-binary-type-for-blob="true">
+            <!-- NOTE: when Postgres JDBC driver updated can set use-tm-join="true" -->
+            <database-type type="number-float" sql-type="FLOAT8"/>
+
+            <database-type type="text-medium" sql-type="TEXT"/>
+            <database-type type="text-intermediate" sql-type="TEXT"/>
+            <database-type type="text-long" sql-type="TEXT"/>
+            <database-type type="text-very-long" sql-type="TEXT"/>
+
+            <database-type type="binary-very-long" sql-type="BYTEA"/>
+
+            <inline-jdbc pool-maxsize="90" jdbc-uri="${entity_ds_url}" jdbc-username="${entity_ds_user}" jdbc-password="${entity_ds_password}"/>
         </database>
     </database-list>
 

--- a/framework/template/XmlActions.groovy.ftl
+++ b/framework/template/XmlActions.groovy.ftl
@@ -17,6 +17,7 @@ import static org.moqui.util.StringUtilities.*
 import java.sql.Timestamp
 import java.sql.Time
 import java.time.*
+import java.util.concurrent.*
 // these are in the context by default: ExecutionContext ec, Map<String, Object> context, Map<String, Object> result
 <#visit xmlActionsRoot/>
 
@@ -69,6 +70,40 @@ return;
         <#else>
         if (ec.message.hasError()) return
         </#if><#t>
+    }
+</#macro>
+
+<#macro "service-schedule">
+    <#assign timeUnit = "MILLISECONDS">
+    <#if .node["@time-unit"]?has_content><#assign timeUnit = .node["@time-unit"]?upper_case></#if>
+    if (true) {
+        ec.service.schedule("${.node["@task-name"]}")<#rt>
+            <#t>.name("${.node.@name}")
+            <#t>.timeUnit(java.util.concurrent.TimeUnit.${timeUnit})
+            <#t><#if .node["@initial-delay"]?has_content>.initialDelay(${.node["@initial-delay"]!0})</#if>
+            <#t><#if .node["@polling-interval"]?has_content && .node["@type"]?has_content && .node["@type"] == "at-fixed-rate">.atFixedRate(${.node["@polling-interval"]})</#if>
+            <#t><#if .node["@polling-interval"]?has_content && .node["@type"]?has_content && .node["@type"] == "with-fixed-delay">.withFixedDelay(${.node["@polling-interval"]})</#if>
+            <#t><#if .node["@duration"]?has_content>.duration(${.node["@duration"]})</#if>
+            <#t><#if .node["@transaction-timeout"]?has_content>.transactionTimeout(${.node["@transaction-timeout"]})</#if>
+            <#if .node["@in-map"]?if_exists == "true">.parameters(context)<#elseif .node["@in-map"]?has_content && .node["@in-map"] != "false">.parameters(${.node["@in-map"]})</#if><#list .node["field-map"] as fieldMap>.parameter("${fieldMap["@field-name"]}",<#if fieldMap["@from"]?has_content>${fieldMap["@from"]}<#elseif fieldMap["@value"]?has_content>"""${fieldMap["@value"]}"""<#else>${fieldMap["@field-name"]}</#if>)</#list>.call()
+        <#if (.node["@ignore-error"]?if_exists == "true")>
+        if (ec.message.hasError()) {
+            ec.logger.warn("Ignoring error running service ${.node.@name}: " + ec.message.getErrorsString())
+            ec.message.clearErrors()
+        }
+        <#else>
+            if (ec.message.hasError()) return
+        </#if><#t>
+    }
+</#macro>
+
+<#macro "cancel-scheduled-service">
+    <#assign timeUnit = "MILLISECONDS">
+    <#if .node["@time-unit"]?has_content><#assign timeUnit = .node["@time-unit"]?upper_case></#if>
+    if (true) {
+        ec.service.schedule("${.node["@task-name"]}")<#rt><#if .node["@cancel-delay"]?has_content>
+            <#t>.cancel(<#if .node["@may-interrupt-if-running"]?if_exists == "true">true<#else>false</#if>, ${.node["@cancel-delay"]}, java.util.concurrent.TimeUnit.${timeUnit})<#else>
+            <#t>.cancel(<#if .node["@may-interrupt-if-running"]?if_exists == "true">true<#else>false</#if>)</#if>
     }
 </#macro>
 

--- a/framework/xsd/moqui-conf-3.xsd
+++ b/framework/xsd/moqui-conf-3.xsd
@@ -77,7 +77,11 @@ along with this software (see the LICENSE.md file). If not, see
                 The maximum size of the worker thread pool.</xs:documentation></xs:annotation></xs:attribute>
             <xs:attribute name="worker-pool-alive" type="xs:integer"><xs:annotation><xs:documentation>
                 The amount of time, in seconds, to keep idle worker threads alive (beyond core pool size).</xs:documentation></xs:annotation></xs:attribute>
-            <xs:attribute name="notification-topic-factory" type="xs:string"><xs:annotation><xs:documentation>
+            <xs:attribute name="scheduled-thread-pool-core" type="xs:integer"><xs:annotation><xs:documentation>
+                The core (minimum) size of the scheduled thread pool.</xs:documentation></xs:annotation></xs:attribute>
+            <xs:attribute name="scheduled-thread-pool-max" type="xs:integer"><xs:annotation><xs:documentation>
+                The maximum size of the scheduled thread pool.</xs:documentation></xs:annotation></xs:attribute>
+<xs:attribute name="notification-topic-factory" type="xs:string"><xs:annotation><xs:documentation>
                 The ToolFactory to use to get a SimpleTopic for distributed NotificationMessage</xs:documentation></xs:annotation></xs:attribute>
         </xs:complexType>
     </xs:element>
@@ -543,9 +547,16 @@ along with this software (see the LICENSE.md file). If not, see
                 <!-- leaving this out for now, not easily supported by Quartz Scheduler: <xs:element minOccurs="0" ref="thread-pool"/> -->
                 <!-- TABLED: not to include in 1.0: <xs:element minOccurs="0" maxOccurs="unbounded" ref="jms-service"/> -->
             </xs:sequence>
-            <xs:attribute name="distributed-factory" type="xs:string"><xs:annotation><xs:documentation>
+            <xs:attribute name="distributed-executor-factory" type="xs:string"><xs:annotation><xs:documentation>
                 The name of the ToolFactory to use for the distributed async service ExecutorService implementation.
             </xs:documentation></xs:annotation></xs:attribute>
+            <xs:attribute name="distributed-scheduled-executor-factory" type="xs:string"><xs:annotation><xs:documentation>
+                The name of the ToolFactory to use for the distributed scheduled service ExecutorService implementation.
+            </xs:documentation></xs:annotation></xs:attribute>
+            <xs:attribute name="scheduled-thread-pool-core" type="xs:integer"><xs:annotation><xs:documentation>
+                The core (minimum) size of the scheduled thread pool.</xs:documentation></xs:annotation></xs:attribute>
+            <xs:attribute name="scheduled-thread-pool-max" type="xs:integer"><xs:annotation><xs:documentation>
+                The maximum size of the scheduled thread pool.</xs:documentation></xs:annotation></xs:attribute>
             <xs:attribute name="scheduled-job-check-time" type="non-neg-int-expandable"><xs:annotation><xs:documentation>
                 How often to check for and run scheduled service jobs in seconds. Set to 0 (zero) to disable.
             </xs:documentation></xs:annotation></xs:attribute>
@@ -640,6 +651,14 @@ along with this software (see the LICENSE.md file). If not, see
             <xs:attribute name="crypt-iter" type="xs:string"/>
             <xs:attribute name="crypt-algo" type="xs:string"/>
             <xs:attribute name="query-stats" default="false" type="boolean-expandable"/>
+            <xs:attribute name="worker-queue" type="xs:integer"><xs:annotation><xs:documentation>
+                The maximum size of the statement worker queue.</xs:documentation></xs:annotation></xs:attribute>
+            <xs:attribute name="worker-pool-core" type="xs:integer"><xs:annotation><xs:documentation>
+                The core (minimum) size of the statement worker thread pool.</xs:documentation></xs:annotation></xs:attribute>
+            <xs:attribute name="worker-pool-max" type="xs:integer"><xs:annotation><xs:documentation>
+                The maximum size of the statement worker thread pool.</xs:documentation></xs:annotation></xs:attribute>
+            <xs:attribute name="worker-pool-alive" type="xs:integer"><xs:annotation><xs:documentation>
+                The amount of time, in seconds, to keep idle statement worker threads alive (beyond core pool size).</xs:documentation></xs:annotation></xs:attribute>
         </xs:complexType>
     </xs:element>
 

--- a/framework/xsd/xml-actions-3.xsd
+++ b/framework/xsd/xml-actions-3.xsd
@@ -185,6 +185,92 @@ along with this software (see the LICENSE.md file). If not, see
         </xs:complexType>
     </xs:element>
     -->
+    <xs:element name="service-schedule" substitutionGroup="CallOperations">
+        <xs:annotation><xs:documentation>Schedule a service execution.</xs:documentation></xs:annotation>
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element minOccurs="0" maxOccurs="unbounded" ref="field-map"/>
+            </xs:sequence>
+            <xs:attribute name="name" type="name-full" use="required">
+                <xs:annotation><xs:documentation>
+                    The combined service name, like: "${path}.${verb}${noun}". To explicitly separate the verb and noun
+                    put a hash (#) between them, like: "${path}.${verb}#${noun}".
+                </xs:documentation></xs:annotation>
+            </xs:attribute>
+            <xs:attribute name="in-map" type="xs:string" default="false">
+                <xs:annotation><xs:documentation>
+                    Creates an in parameters with variables matching the names of service in-parameters elements, doing
+                    type conversions as needed.
+
+                    If false (default) does nothing. If true constructs an in-map from the context.
+                    Otherwise is the name of a Map in the context uses it as the source Map for the service context.
+                </xs:documentation></xs:annotation>
+            </xs:attribute>
+            <xs:attribute name="task-name" type="xs:string" use="required">
+                <xs:annotation><xs:documentation>Set a unique task name for the scheduled service.</xs:documentation></xs:annotation>
+            </xs:attribute>
+            <xs:attribute name="type" default="one-shot">
+                <xs:annotation>
+                    <xs:documentation>
+                        The scheduling type used to run the task. Possible values:
+                            - one-shot
+                              Schedules and executes a one-shot service that becomes enabled after the given delay.
+                            - at-fixed-rate
+                              Schedules a periodic service that becomes enabled first after the given initial delay, and subsequently with the given period; that is executions will commence after initialDelay then initialDelay+period, then initialDelay + 2 * period, and so on.
+                            - with-fixed-delay
+                              Schedules a periodic service that becomes enabled first after the given initial delay, and subsequently with the given delay between the termination of one execution and the commencement of the next.
+                    </xs:documentation>
+                </xs:annotation>
+                <xs:simpleType>
+                    <xs:restriction base="xs:token">
+                        <xs:enumeration value="one-shot"/>
+                        <xs:enumeration value="at-fixed-rate"/>
+                        <xs:enumeration value="with-fixed-delay"/>
+                    </xs:restriction>
+                </xs:simpleType>
+            </xs:attribute>
+            <xs:attribute name="time-unit" type="xs:string" default="MILLISECONDS">
+                <xs:annotation><xs:documentation>The time unit, in java.util.concurrent.TimeUnit format, for all time parameters. Defaults to milliseconds.</xs:documentation></xs:annotation>
+            </xs:attribute>
+            <xs:attribute name="initial-delay" type="xs:integer" default="0">
+                <xs:annotation><xs:documentation>The task becomes enabled after the given initial delay. Defaults to 0.</xs:documentation></xs:annotation>
+            </xs:attribute>
+            <xs:attribute name="polling-interval" type="xs:integer" default="-1">
+                <xs:annotation><xs:documentation>Configure a cyclical service. The service is repeated, with the given polling interval,
+                    at fixed rate or with a fixed delay between the termination of one execution and the commencement of the next.</xs:documentation></xs:annotation>
+            </xs:attribute>
+            <xs:attribute name="duration" type="xs:integer">
+                <xs:annotation><xs:documentation>The duration of the execution of the periodic task. After this interval the cyclical task will be canceled.</xs:documentation></xs:annotation>
+            </xs:attribute>
+            <xs:attribute name="transaction-timeout" type="xs:int" default="0">
+                <xs:annotation><xs:documentation>
+                    Defines the timeout for the transaction, in seconds.
+                    This value is only used if this service begins a transaction (either require-new, or
+                    use-or-begin and there is no other transaction already in place).
+                </xs:documentation></xs:annotation>
+            </xs:attribute>
+        </xs:complexType>
+    </xs:element>
+    <xs:element name="cancel-scheduled-service" substitutionGroup="CallOperations">
+        <xs:annotation><xs:documentation>
+            Attempts to cancel the scheduled execution of the service given the task name.
+            Do nothing if this scheduled service was cancelled before it completed normally.
+        </xs:documentation></xs:annotation>
+        <xs:complexType>
+            <xs:attribute name="task-name" type="xs:string" use="required">
+                <xs:annotation><xs:documentation>Set a unique task name to get the scheduled service.</xs:documentation></xs:annotation>
+            </xs:attribute>
+            <xs:attribute name="may-interrupt-if-running" type="boolean" default="true">
+                <xs:annotation><xs:documentation>If true the service should be interrupted; otherwise, in-progress services are allowed to complete.</xs:documentation></xs:annotation>
+            </xs:attribute>
+            <xs:attribute name="cancel-delay" type="xs:integer">
+                <xs:annotation><xs:documentation>Cancel the execution of the periodic task after the specified delay. If omitted cancels immediately. Must be greater than 0 when specified.</xs:documentation></xs:annotation>
+            </xs:attribute>
+            <xs:attribute name="time-unit" type="xs:string" default="MILLISECONDS">
+                <xs:annotation><xs:documentation>The time unit, in java.util.concurrent.TimeUnit format, for all time parameters. Defaults to milliseconds.</xs:documentation></xs:annotation>
+            </xs:attribute>
+        </xs:complexType>
+    </xs:element>
 
     <xs:element name="script" substitutionGroup="CallOperations">
         <xs:annotation><xs:documentation>
@@ -419,7 +505,7 @@ along with this software (see the LICENSE.md file). If not, see
 
                 The fields and special fields with suffixes supported are the same as the *-find fields in the XML
                 Forms. This means that you can use this to process the data from the various inputs generated by XML
-                Forms. The suffixes include things like *_op for operators and *_ic for ignore case.  
+                Forms. The suffixes include things like *_op for operators and *_ic for ignore case.
 
                 For historical reference, this does basically what the Apache OFBiz prepareFind service does.
             </xs:documentation>


### PR DESCRIPTION
Adds a scheduled service API, XML actions for scheduling and cancellation, and configuration support for an optional distributed scheduled executor.

Files changed:
- framework/src/main/groovy/org/moqui/impl/service/ServiceFacadeImpl.groovy
- framework/src/main/groovy/org/moqui/impl/service/ServiceCallScheduledImpl.groovy
- framework/src/main/java/org/moqui/service/ServiceFacade.java
- framework/src/main/java/org/moqui/service/ServiceCallScheduled.java
- framework/template/XmlActions.groovy.ftl
- framework/xsd/moqui-conf-3.xsd
- framework/xsd/xml-actions-3.xsd
- framework/src/main/resources/MoquiDefaultConf.xml

Validation performed:
- git diff --check
- xmllint --noout on changed XSD/XML files
- ./gradlew framework:compileJava framework:compileGroovy framework:testClasses

This PR supersedes moqui/moqui-framework#719.
