### PR TITLE
Fix 'Could not find matching constructor'  while change password for users

### DIFF
--- a/framework/service/org/moqui/impl/UserServices.xml
+++ b/framework/service/org/moqui/impl/UserServices.xml
@@ -209,7 +209,7 @@ along with this software (see the LICENSE.md file). If not, see
                         <return message="Please enter current password" public="true" type="danger"/></if>
 
                     <script>
-                        def passwordSalt =  (userAccount.passwordSalt?:'') as String
+                        passwordSalt =  (userAccount.passwordSalt?:'') as String
                         def token = new org.apache.shiro.authc.UsernamePasswordToken((String) userAccount.username, (String) oldPassword)
                         def info = new org.apache.shiro.authc.SimpleAuthenticationInfo(userAccount.username, userAccount.currentPassword,
                                 new org.apache.shiro.lang.util.SimpleByteSource(passwordSalt), "moquiRealm")
@@ -218,7 +218,7 @@ along with this software (see the LICENSE.md file). If not, see
                         <if condition="userAccount.resetPassword"><then>
                             <!-- try the resetPassword -->
                             <script>
-                                def passwordSalt =  (userAccount.passwordSalt?:'') as String
+                                passwordSalt =  (userAccount.passwordSalt?:'') as String
                                 info = new org.apache.shiro.authc.SimpleAuthenticationInfo(userAccount.username, userAccount.resetPassword,
                                         new org.apache.shiro.lang.util.SimpleByteSource(passwordSalt), "moquiRealm")
                             </script>

--- a/framework/service/org/moqui/impl/UserServices.xml
+++ b/framework/service/org/moqui/impl/UserServices.xml
@@ -209,16 +209,18 @@ along with this software (see the LICENSE.md file). If not, see
                         <return message="Please enter current password" public="true" type="danger"/></if>
 
                     <script>
+                        def passwordSalt =  (userAccount.passwordSalt?:'') as String
                         def token = new org.apache.shiro.authc.UsernamePasswordToken((String) userAccount.username, (String) oldPassword)
                         def info = new org.apache.shiro.authc.SimpleAuthenticationInfo(userAccount.username, userAccount.currentPassword,
-                                userAccount.passwordSalt ? new org.apache.shiro.lang.util.SimpleByteSource((String) userAccount.passwordSalt) : '', "moquiRealm")
+                                new org.apache.shiro.lang.util.SimpleByteSource(passwordSalt), "moquiRealm")
                     </script>
                     <if condition="!userAccount.currentPassword || !ec.ecfi.getCredentialsMatcher(userAccount.passwordHashType, 'Y'.equals(userAccount.passwordBase64)).doCredentialsMatch(token, info)">
                         <if condition="userAccount.resetPassword"><then>
                             <!-- try the resetPassword -->
                             <script>
+                                def passwordSalt =  (userAccount.passwordSalt?:'') as String
                                 info = new org.apache.shiro.authc.SimpleAuthenticationInfo(userAccount.username, userAccount.resetPassword,
-                                        userAccount.passwordSalt ? new org.apache.shiro.lang.util.SimpleByteSource((String) userAccount.passwordSalt) : '', "moquiRealm")
+                                        new org.apache.shiro.lang.util.SimpleByteSource(passwordSalt), "moquiRealm")
                             </script>
                             <if condition="!ec.ecfi.getCredentialsMatcher(userAccount.passwordHashType, 'Y'.equals(userAccount.passwordBase64)).doCredentialsMatch(token, info)">
                                 <return message="Password did not match current password or reset password for user ${username}" public="true" type="danger"/></if>


### PR DESCRIPTION
SimpleAuthenticationInfo expects a ByteSource as its salt argument. Passing an empty string for accounts without a password salt caused Groovy to resolve an invalid String, String, String, String constructor.

This matches the pattern used by MoquiShiroRealm.getAuthenticationInfo and applies to both current-password and reset-password verification.