### PR TITLE
Fix incorrect XML attribute name for job thread pool alive time worker-pool-alive was being read instead of job-pool-alive

### DIFF
--- a/framework/src/main/groovy/org/moqui/impl/service/ServiceFacadeImpl.groovy
+++ b/framework/src/main/groovy/org/moqui/impl/service/ServiceFacadeImpl.groovy
@@ -97,7 +97,7 @@ class ServiceFacadeImpl implements ServiceFacade {
             logger.info("Setting Service Job worker pool size to ${availableProcessorsSize} based on available processors * 2")
             maxSize = availableProcessorsSize
         }
-        long aliveTime = (serviceFacadeNode.attribute("worker-pool-alive") ?: "120") as long
+        long aliveTime = (serviceFacadeNode.attribute("job-pool-alive") ?: "120") as long
 
         logger.info("Initializing Service Job ThreadPoolExecutor: queue limit ${jobQueueMax}, pool-core ${coreSize}, pool-max ${maxSize}, pool-alive ${aliveTime}s")
         // make the actual queue at least maxSize to allow for stuffing the queue to get it to add threads to the pool


### PR DESCRIPTION
worker-pool-alive was being read instead of job-pool-alive when
configuring the Service Job ThreadPoolExecutor keep-alive time, causing
the setting to be silently ignored and always use the worker-pool-alive setting