### PR TITLE
Reset PreparedStatement.maxRows on pooled statements

### DIFF
--- a/framework/src/main/groovy/org/moqui/impl/entity/EntityFindBuilder.java
+++ b/framework/src/main/groovy/org/moqui/impl/entity/EntityFindBuilder.java
@@ -777,7 +777,10 @@ public class EntityFindBuilder extends EntityQueryBuilder {
             ps = connection.prepareStatement(finalSql, entityFindBase.getResultSetType(), entityFindBase.getResultSetConcurrency());
             Integer maxRows = entityFindBase.getMaxRows();
             Integer fetchSize = entityFindBase.getFetchSize();
-            if (maxRows != null && maxRows > 0) ps.setMaxRows(maxRows);
+            // NOTE: always set max rows (0 means no limit), otherwise a pooled/cached PreparedStatement retains the
+            // maxRows from a prior find and silently truncates later results (or on some DBs, like H2, makes the
+            // default fetch size exceed maxRows and throw)
+            if (maxRows != null && maxRows > 0) { ps.setMaxRows(maxRows); } else { ps.setMaxRows(0); }
             // NOTE: always set a fetch size, without explicit fetch size some JDBC drivers (like MySQL Connector/J) will try to fetch all rows
             // NOTE: the default here of 1000 is a balance between memory use and network overhead, 100 rows generally being easy to accommodate
             if (fetchSize != null && fetchSize > 0) { ps.setFetchSize(fetchSize); } else { ps.setFetchSize(100); }

--- a/framework/src/test/groovy/EntityFindTests.groovy
+++ b/framework/src/test/groovy/EntityFindTests.groovy
@@ -129,6 +129,38 @@ class EntityFindTests extends Specification {
         noEnums.size() == 0
     }
 
+    def "maxRows does not leak onto pooled PreparedStatement"() {
+        // A find that sets maxRows leaves that limit on the cached (pooled) PreparedStatement.
+        // A later find with identical SQL but no maxRows must not inherit the stale limit.
+        // Both finds produce the same SQL text (maxRows uses JDBC setMaxRows, not SQL), so the
+        // Bitronix statement cache returns the same PreparedStatement for the second find.
+        // Uses the non-cached TestEntity so the finds actually hit the DB / pooled statement.
+        setup:
+        for (int i = 1; i <= 5; i++)
+            ec.entity.makeValue("moqui.test.TestEntity")
+                    .setAll([testId: "MAXR" + i, testNumberInteger: 9999, testMedium: "maxRows test " + i])
+                    .createOrUpdate()
+
+        when:
+        // first find sets maxRows on the (pooled) PreparedStatement for this SQL;
+        // fetchSize<=maxRows so the statement is valid on databases (like H2) that require it
+        EntityList limited = ec.entity.find("moqui.test.TestEntity")
+                .condition("testNumberInteger", 9999).orderBy("testId").maxRows(2).fetchSize(2).list()
+        // second find reuses the same cached statement (identical SQL) with no maxRows: it must
+        // NOT inherit the stale maxRows=2 (which would truncate to 2 rows, or on H2 make the
+        // default fetchSize=100 exceed maxRows and throw)
+        EntityList full = ec.entity.find("moqui.test.TestEntity")
+                .condition("testNumberInteger", 9999).orderBy("testId").list()
+
+        then:
+        limited.size() == 2
+        full.size() == 5
+
+        cleanup:
+        for (int i = 1; i <= 5; i++)
+            ec.entity.makeValue("moqui.test.TestEntity").set("testId", "MAXR" + i).delete()
+    }
+
     def "auto cache clear for list"() {
         // update the testMedium and make sure we get the new value
         when:


### PR DESCRIPTION
## Problem

`EntityFindBuilder.makePreparedStatement()` sets `maxRows` only when a positive value is requested, and never resets it otherwise:

```java
if (maxRows != null && maxRows > 0) ps.setMaxRows(maxRows);   // never reset to 0
```

The default transaction manager caches prepared statements — `TransactionInternalBitronix` calls `setPreparedStatementCacheSize(100)`. JDBC's `maxRows` is statement-level state that survives statement caching, so a `PreparedStatement` returned from the pool keeps the `maxRows` set by a **prior** find. A later find with the **same SQL** but no `maxRows` then inherits the stale limit:

- **Silent truncation** on most databases (e.g. a paginated find with `maxRows=20` leaves `20` on the pooled statement; the next unbounded find with the same SQL returns at most 20 rows).
- **Hard failure on H2**, which requires `fetchSize <= maxRows`: the next find's default `setFetchSize(100)` throws `Invalid value "100" for parameter "rows"` because the stale `maxRows` is smaller.

## Fix

Always call `setMaxRows`, using `0` (JDBC "no limit") when no positive value is requested — mirroring the always-set `setFetchSize` handling on the very next line, which already avoids this exact trap:

```java
if (maxRows != null && maxRows > 0) { ps.setMaxRows(maxRows); } else { ps.setMaxRows(0); }
```

This is the only site that calls `setMaxRows`, and it is shared by the list/iterator and count paths, so the reset covers all finds.

## Testing

Adds `EntityFindTests > "maxRows does not leak onto pooled PreparedStatement"`, using the non-cached `TestEntity` so the finds actually build and execute a pooled statement: a first find with `.maxRows(2)` followed by an identical-SQL find with no `maxRows` must return the full result set. The test fails before the change (on H2, throws `Invalid value "100" for parameter "rows"` on the second find) and passes after. A full `:framework:test` run showed no regressions.