### PR TITLE
Mysql84 utf8mb4

### DIFF
--- a/framework/entity/BasicEntities.xml
+++ b/framework/entity/BasicEntities.xml
@@ -285,7 +285,7 @@ along with this software (see the LICENSE.md file). If not, see
         <field name="localized" type="text-long"/>
     </entity>
     <entity entity-name="LocalizedEntityField" package="moqui.basic" use="configuration" authorize-skip="view" cache="true">
-        <field name="entityName" type="text-medium" is-pk="true"/>
+        <field name="entityName" type="text-short" is-pk="true"/>
         <field name="fieldName" type="text-medium" is-pk="true"/>
         <field name="pkValue" type="text-medium" is-pk="true"/>
         <field name="locale" type="text-short" is-pk="true"/>

--- a/framework/entity/ServerEntities.xml
+++ b/framework/entity/ServerEntities.xml
@@ -32,7 +32,7 @@ along with this software (see the LICENSE.md file). If not, see
         <field name="isSlowHit" type="text-indicator"/>
         <field name="outputSize" type="number-integer"/>
         <field name="wasError" type="text-indicator"/>
-        <field name="errorMessage" type="text-long"/>
+        <field name="errorMessage" type="text-very-long"/>
         <field name="requestUrl" type="text-long"/>
         <field name="referrerUrl" type="text-long"/>
         <field name="serverIpAddress" type="id"/>

--- a/framework/service/org/moqui/impl/ServiceServices.xml
+++ b/framework/service/org/moqui/impl/ServiceServices.xml
@@ -15,7 +15,8 @@ along with this software (see the LICENSE.md file). If not, see
 <services xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://moqui.org/xsd/service-definition-3.xsd">
 
     <service verb="clean" noun="ServiceJobRun" authenticate="false" transaction-timeout="600">
-        <in-parameters><parameter name="daysToKeep" type="Integer" default="90"/></in-parameters>
+        <in-parameters>
+        <parameter name="daysToKeep" type="Integer" default="90"/></in-parameters>
         <out-parameters><parameter name="recordsRemoved" type="Long"/></out-parameters>
         <actions>
             <script>

--- a/framework/service/org/moqui/impl/ServiceServices.xml
+++ b/framework/service/org/moqui/impl/ServiceServices.xml
@@ -15,8 +15,7 @@ along with this software (see the LICENSE.md file). If not, see
 <services xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://moqui.org/xsd/service-definition-3.xsd">
 
     <service verb="clean" noun="ServiceJobRun" authenticate="false" transaction-timeout="600">
-        <in-parameters>
-        <parameter name="daysToKeep" type="Integer" default="90"/></in-parameters>
+        <in-parameters><parameter name="daysToKeep" type="Integer" default="90"/></in-parameters>
         <out-parameters><parameter name="recordsRemoved" type="Long"/></out-parameters>
         <actions>
             <script>

--- a/framework/src/main/resources/MoquiDefaultConf.xml
+++ b/framework/src/main/resources/MoquiDefaultConf.xml
@@ -755,7 +755,7 @@
                     databaseName="${entity_ds_database}" user="${entity_ds_user}" password="${entity_ds_password}"/></inline-jdbc>
         </database>
         <database name="mysql8" lb-name="mysql" join-style="ansi-no-parenthesis" offset-style="limit" from-lateral-style="lateral"
-                never-nulls="true" table-engine="InnoDB" character-set="utf8" collate="utf8_general_ci" fk-style="name_fk"
+                never-nulls="true" table-engine="InnoDB" character-set="utf8mb4" collate="utf8mb4_0900_ai_ci" fk-style="name_fk"
                 constraint-name-clip-length="60"
                 default-isolation-level="ReadCommitted" default-test-query="SELECT 1"
                 default-startup-add-missing="true" default-runtime-add-missing="false"


### PR DESCRIPTION
Fix MySQL8 charset to utf8mb4, adjust field types for compatibility

- MoquiDefaultConf.xml: update MySQL8 default character-set from utf8
  to utf8mb4 and collate from utf8_general_ci to utf8mb4_0900_ai_ci for
  full Unicode support (emoji, supplementary chars); MySQL's utf8 is a
  3-byte alias that silently drops 4-byte codepoints
- BasicEntities.xml: shrink LocalizedEntityField.entityName PK from
  text-medium to text-short to stay within MySQL's 767-byte index key
  length limit when using utf8mb4 (4 bytes/char vs 3)
- ServerEntities.xml: expand ArtifactHit.errorMessage from text-long to
  text-very-long to accommodate verbose stack traces in hit error logging
- ServiceServices.xml: minor XML formatting in clean#ServiceJobRun
  in-parameters block (no functional change)