### PR TITLE
fix(tarpit): compare hit age against maxHitsDuration in the same unit

### DIFF
--- a/framework/src/main/groovy/org/moqui/impl/context/ArtifactExecutionFacadeImpl.groovy
+++ b/framework/src/main/groovy/org/moqui/impl/context/ArtifactExecutionFacadeImpl.groovy
@@ -506,7 +506,12 @@ class ArtifactExecutionFacadeImpl implements ArtifactExecutionFacade {
                         ArrayList<Long> hitTimeListCopy = new ArrayList<Long>(hitTimeList)
                         for (int htlInd = 0; htlInd < hitTimeListCopy.size(); htlInd++) {
                             Long hitTime = (Long) hitTimeListCopy.get(htlInd)
-                            if (hitTime != null && ((hitTime - checkTime) < maxHitsDuration)) hitsInDuration++
+                            // NOTE: hitTime and checkTime are in milliseconds while maxHitsDuration is in
+                            // seconds (see the ArtifactTarpit entity description). The previous comparison
+                            // (hitTime - checkTime) was always negative for past hits and therefore always
+                            // below the limit, so every cached hit was counted regardless of its age and
+                            // maxHitsDuration had no effect: the tarpit triggered earlier than configured.
+                            if (hitTime != null && ((checkTime - hitTime) < (maxHitsDuration * 1000L))) hitsInDuration++
                         }
                     }
                     // logger.warn("TOREMOVE artifact [${tarpitKey}], now has ${hitsInDuration} hits in ${maxHitsDuration} seconds")


### PR DESCRIPTION
hitTime and checkTime are milliseconds; maxHitsDuration is seconds. For any hit already recorded, hitTime - checkTime is negative and therefore always lower than a positive maxHitsDuration, so the condition is always true: every cached hit is counted regardless of how old it is.